### PR TITLE
ci: add minimal Vercel deploy workflow (Vercel auto-deploy on push)

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,30 @@
+name: Vercel Deploy
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy to Vercel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy with Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-args: ${{ github.ref == 'refs/heads/main' && '--prod' || '' }}
+          working-directory: ./
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+


### PR DESCRIPTION
This PR adds a minimal GitHub Actions workflow to deploy to Vercel on every push.

What’s included:
- .github/workflows/vercel-deploy.yml using amondnet/vercel-action
- Uses repo secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
- Preview deploys for branches; production deploys on main

Notes:
- Base44 workflow remains in repo but is not modified in this PR. If you want, I can disable it in a follow-up PR.
- Stripe test-mode setup is completed via MCP, and billing_prices have payment_link_url populated in Supabase.

Merging this will enable auto-deploy to Vercel for live changes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author