### PR TITLE
feat(auth): make Landing default, add /register, and remove loggingService usage from client services

### DIFF
--- a/src/components/auth/RegisterForm.jsx
+++ b/src/components/auth/RegisterForm.jsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react'
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuth } from '@/contexts/AuthContext'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Loader2, Mail, Lock, User } from 'lucide-react'
+import ErrorBoundary from '@/components/ErrorBoundary'
+
+export default function RegisterFormWithBoundary() {
+  return (
+    <ErrorBoundary>
+      <RegisterForm />
+    </ErrorBoundary>
+  )
+}
+
+function RegisterForm() {
+  const { register, isAuthenticated, isLoading } = useAuth()
+  const location = useLocation()
+  const [form, setForm] = useState({ email: '', password: '', full_name: '' })
+  const [showPassword, setShowPassword] = useState(false)
+
+  if (isAuthenticated) {
+    const from = location.state?.from?.pathname || '/dashboard'
+    return <Navigate to={from} replace />
+  }
+
+  const onChange = (e) => {
+    const { name, value } = e.target
+    setForm((f) => ({ ...f, [name]: value }))
+  }
+
+  const onSubmit = async (e) => {
+    e.preventDefault()
+    if (!form.email || !form.password) return
+    await register({ email: form.email, password: form.password, full_name: form.full_name })
+    // Supabase may require email verification; the AuthProvider will reflect state
+    window.location.href = '/dashboard'
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-emerald-50 to-blue-50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center space-y-2">
+          <div className="mx-auto w-16 h-16 bg-gradient-to-br from-emerald-600 to-emerald-900 rounded-xl flex items-center justify-center">
+            <span className="text-2xl font-bold text-white">P</span>
+          </div>
+          <div>
+            <CardTitle className="text-2xl font-bold text-gray-900">Create your account</CardTitle>
+            <CardDescription className="text-base mt-1">Sign up for PIKAR AI</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="full_name">Full name (optional)</Label>
+              <div className="relative">
+                <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <Input id="full_name" name="full_name" value={form.full_name} onChange={onChange} placeholder="Your name" className="pl-10" disabled={isLoading} />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email address</Label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <Input id="email" name="email" type="email" value={form.email} onChange={onChange} placeholder="you@example.com" className="pl-10" autoComplete="email" required disabled={isLoading} />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <Input id="password" name="password" type={showPassword ? 'text' : 'password'} value={form.password} onChange={onChange} placeholder="••••••••" className="pl-10 pr-10" autoComplete="new-password" required disabled={isLoading} />
+                <button type="button" className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600" onClick={() => setShowPassword((s) => !s)}>
+                  {showPassword ? 'Hide' : 'Show'}
+                </button>
+              </div>
+            </div>
+            <Button type="submit" className="w-full" disabled={isLoading || !form.email || !form.password}>
+              {isLoading ? (<><Loader2 className="w-4 h-4 mr-2 animate-spin" />Creating account...</>) : 'Create account'}
+            </Button>
+            <Button type="button" variant="outline" className="w-full" onClick={() => (window.location.href = '/login')} disabled={isLoading}>
+              Already have an account? Sign in
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -413,6 +413,7 @@ export default function Pages() {
             <Routes>
                 <Route path="/" element={<Landing />} />
                 <Route path="/login" element={<LoginForm />} />
+                <Route path="/auth" element={<LoginForm />} />
                 <Route path="/register" element={<RegisterForm />} />
                 <Route path="/pricing" element={<Pricing />} />
                 <Route path="/billing" element={<Billing />} />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -12,6 +12,7 @@ import Agents from './admin/Agents';
 import Pricing from './Pricing';
 import Billing from './Billing';
 import LoginForm from "@/components/auth/LoginForm";
+import RegisterForm from "@/components/auth/RegisterForm";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 
 import Dashboard from "./Dashboard";
@@ -281,7 +282,6 @@ function PagesContent() {
                 <ProtectedRoute>
                     <Layout currentPageName={currentPage}>
                         <Routes>
-                            <Route path="/" element={<Dashboard />} />
                             <Route path="/dashboard" element={<Dashboard />} />
                             <Route path="/Dashboard" element={<Dashboard />} />
                 
@@ -412,6 +412,10 @@ export default function Pages() {
         <Router>
             <Routes>
                 <Route path="/" element={<Landing />} />
+                <Route path="/login" element={<LoginForm />} />
+                <Route path="/register" element={<RegisterForm />} />
+                <Route path="/pricing" element={<Pricing />} />
+                <Route path="/billing" element={<Billing />} />
                 <Route path="/admin" element={<AdminProtectedRoute><AdminLayout /></AdminProtectedRoute>}>
                   <Route index element={<AdminDashboard />} />
                   <Route path="users" element={<AdminUsers />} />
@@ -421,10 +425,8 @@ export default function Pages() {
                   <Route path="agents" element={<Agents />} />
                   <Route path="settings" element={<AdminSettings />} />
                 </Route>
-                <Route path="/pricing" element={<Pricing />} />
-                <Route path="/billing" element={<Billing />} />
+                <Route path="/*" element={<PagesContent />} />
             </Routes>
-            <PagesContent />
         </Router>
     );
 }

--- a/src/services/emailNotificationService.js
+++ b/src/services/emailNotificationService.js
@@ -4,7 +4,6 @@
  */
 
 import { auditService } from './auditService'
-import { loggingService } from './loggingService'
 import { environmentConfig } from '@/config/environment'
 
 class EmailNotificationService {
@@ -183,7 +182,7 @@ class EmailNotificationService {
     try {
       // Check if user has opted out of this notification type
       if (!this.canSendNotification(userId, notificationType)) {
-        loggingService.info('Notification blocked by user preferences', {
+        console.info('Notification blocked by user preferences', {
           userId,
           notificationType
         })

--- a/src/services/paymentService.js
+++ b/src/services/paymentService.js
@@ -5,7 +5,6 @@
 
 import { supabase } from '@/lib/supabase'
 import { auditService } from './auditService'
-import { loggingService } from './loggingService'
 import { tierService } from './tierService'
 import { emailNotificationService } from './emailNotificationService'
 import { environmentConfig } from '@/config/environment'

--- a/src/services/tierService.js
+++ b/src/services/tierService.js
@@ -4,7 +4,6 @@
  */
 
 import { auditService } from './auditService'
-import { loggingService } from './loggingService'
 import { environmentConfig } from '@/config/environment'
 
 class TierService {
@@ -488,7 +487,7 @@ class TierService {
     
     this.usageTracking.set(userId, resetUsage)
     
-    loggingService.info('User usage reset', {
+    console.info('User usage reset', {
       userId,
       resetDate: new Date().toISOString()
     })
@@ -697,7 +696,7 @@ class TierService {
       usage.lastUpdated = Date.now()
     }
     
-    loggingService.info('Daily quotas reset for all users')
+    console.info('Daily quotas reset for all users')
   }
 
   /**
@@ -711,7 +710,7 @@ class TierService {
       usage.lastUpdated = Date.now()
     }
     
-    loggingService.info('Monthly quotas reset for all users')
+    console.info('Monthly quotas reset for all users')
   }
 
   /**


### PR DESCRIPTION
- Landing page is now the public root '/'
- Added public /login and /register routes
- Implemented RegisterForm using existing AuthContext.register
- Removed loggingService dependency from browser-facing services to avoid bundling issues
- Build passes

After merge and deploy, auth pages will be accessible from CTAs and top menu, while app routes remain protected.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author