### PR TITLE
feat: add LandingPagesWidget with import, publish, and duplicate

### DIFF
--- a/frontend/src/components/layout/RecentWidgets.tsx
+++ b/frontend/src/components/layout/RecentWidgets.tsx
@@ -40,6 +40,7 @@ const WIDGET_TYPE_ICON: Record<WidgetType, React.ElementType> = {
   self_improvement: Zap,
   workflow_observability: Workflow,
   workflow_timeline: Workflow,
+  landing_pages: FileText,
 };
 
 function widgetIcon(type: WidgetType): React.ElementType {

--- a/frontend/src/components/widgets/LandingPagesWidget.tsx
+++ b/frontend/src/components/widgets/LandingPagesWidget.tsx
@@ -1,0 +1,388 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { WidgetDefinition } from '@/types/widgets';
+import {
+    FileText,
+    Globe,
+    Copy,
+    Trash2,
+    Upload,
+    ExternalLink,
+    Plus,
+    ChevronDown,
+    ChevronUp,
+} from 'lucide-react';
+import {
+    LandingPage,
+    listPages,
+    publishPage,
+    unpublishPage,
+    deletePage,
+    duplicatePage,
+    importPage,
+} from '@/services/landing-pages';
+
+interface Props {
+    definition: WidgetDefinition;
+    onAction?: (action: string, data: unknown) => void;
+}
+
+function formatRelativeTime(dateStr: string): string {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffSecs = Math.floor(diffMs / 1000);
+    const diffMins = Math.floor(diffSecs / 60);
+    const diffHours = Math.floor(diffMins / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    if (diffDays > 0) return `${diffDays}d ago`;
+    if (diffHours > 0) return `${diffHours}h ago`;
+    if (diffMins > 0) return `${diffMins}m ago`;
+    return 'just now';
+}
+
+export default function LandingPagesWidget({ definition, onAction }: Props) {
+    const [pages, setPages] = useState<LandingPage[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [expandedId, setExpandedId] = useState<string | null>(null);
+    const [showImport, setShowImport] = useState(false);
+    const [importTitle, setImportTitle] = useState('');
+    const [importHtml, setImportHtml] = useState('');
+    const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+    useEffect(() => {
+        listPages()
+            .then(({ pages: p }) => {
+                setPages(p);
+                setLoading(false);
+            })
+            .catch((err: unknown) => {
+                setError(err instanceof Error ? err.message : 'Failed to load pages');
+                setLoading(false);
+            });
+    }, []);
+
+    const publishedCount = pages.filter(p => p.published).length;
+    const draftCount = pages.filter(p => !p.published).length;
+    const totalLeads = pages.reduce((sum, p) => sum + (p.submission_count ?? 0), 0);
+
+    const recentPages = pages.slice(0, 5);
+
+    const handleToggleExpand = (id: string) => {
+        setExpandedId(prev => (prev === id ? null : id));
+    };
+
+    const handlePublishToggle = async (page: LandingPage) => {
+        // Optimistic update
+        setPages(prev =>
+            prev.map(p =>
+                p.id === page.id
+                    ? { ...p, published: !p.published, published_at: !p.published ? new Date().toISOString() : null }
+                    : p
+            )
+        );
+        try {
+            if (page.published) {
+                await unpublishPage(page.id);
+            } else {
+                await publishPage(page.id);
+            }
+        } catch {
+            // Revert on error
+            setPages(prev =>
+                prev.map(p =>
+                    p.id === page.id ? { ...p, published: page.published, published_at: page.published_at } : p
+                )
+            );
+        }
+    };
+
+    const handleDuplicate = async (page: LandingPage) => {
+        try {
+            const result = await duplicatePage(page.id);
+            const newPage: LandingPage = {
+                id: result.page_id,
+                title: `${page.title} (copy)`,
+                slug: result.slug,
+                published: false,
+                published_at: null,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                metadata: {},
+                submission_count: 0,
+            };
+            setPages(prev => [newPage, ...prev]);
+        } catch {
+            // silently fail — could add toast here
+        }
+    };
+
+    const handleDeleteConfirm = async (pageId: string) => {
+        // Optimistic remove
+        setPages(prev => prev.filter(p => p.id !== pageId));
+        setConfirmDeleteId(null);
+        if (expandedId === pageId) setExpandedId(null);
+        try {
+            await deletePage(pageId);
+        } catch {
+            // Could refresh list here
+        }
+    };
+
+    const handleImportSubmit = async () => {
+        if (!importTitle.trim() || !importHtml.trim()) return;
+        try {
+            const result = await importPage(importTitle, importHtml);
+            const newPage: LandingPage = {
+                id: result.page_id,
+                title: importTitle,
+                slug: result.slug,
+                published: false,
+                published_at: null,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                metadata: {},
+                submission_count: 0,
+            };
+            setPages(prev => [newPage, ...prev]);
+            setShowImport(false);
+            setImportTitle('');
+            setImportHtml('');
+        } catch {
+            // Could show error
+        }
+    };
+
+    return (
+        <div className="w-full bg-slate-900 text-slate-100 rounded-lg border border-slate-700 overflow-hidden">
+            {/* Header */}
+            <div className="px-4 py-3 border-b border-slate-700 bg-slate-800/80 flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                    <FileText className="w-4 h-4 text-slate-400" />
+                    <h3 className="font-semibold text-slate-100">
+                        {definition.title || 'Landing Pages'}
+                    </h3>
+                </div>
+                <button
+                    onClick={() => onAction?.('create_landing_page', {})}
+                    className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-indigo-300 border border-indigo-500/40 rounded hover:bg-indigo-500/20 transition-colors"
+                >
+                    <Plus className="w-3 h-3" />
+                    Create New
+                </button>
+            </div>
+
+            {/* Quick Stats */}
+            <div className="flex gap-4 px-4 py-2.5 border-b border-slate-700/60 bg-slate-800/40">
+                <div className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-green-500"></span>
+                    <span className="text-xs text-slate-400">
+                        <span className="font-semibold text-green-400">{publishedCount}</span> Published
+                    </span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-slate-500"></span>
+                    <span className="text-xs text-slate-400">
+                        <span className="font-semibold text-slate-300">{draftCount}</span> Drafts
+                    </span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-blue-500"></span>
+                    <span className="text-xs text-slate-400">
+                        <span className="font-semibold text-blue-400">{totalLeads}</span> Total Leads
+                    </span>
+                </div>
+            </div>
+
+            {/* Body */}
+            <div className="p-3 space-y-2">
+                {loading && (
+                    <div className="text-center py-6 text-slate-500 text-sm">Loading pages…</div>
+                )}
+
+                {error && (
+                    <div className="text-center py-4 text-red-400 text-sm">{error}</div>
+                )}
+
+                {!loading && !error && recentPages.length === 0 && !showImport && (
+                    <div className="text-center py-8 space-y-3">
+                        <p className="text-sm text-slate-400">
+                            No landing pages yet — ask me to create one or import from Stitch
+                        </p>
+                        <div className="flex justify-center gap-2">
+                            <button
+                                onClick={() => onAction?.('create_landing_page', {})}
+                                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-indigo-300 border border-indigo-500/40 rounded hover:bg-indigo-500/20 transition-colors"
+                            >
+                                <Plus className="w-3 h-3" />
+                                Create Page
+                            </button>
+                            <button
+                                onClick={() => setShowImport(true)}
+                                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-slate-300 border border-slate-600 rounded hover:bg-slate-700 transition-colors"
+                            >
+                                <Upload className="w-3 h-3" />
+                                Import HTML
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {!loading && !error && recentPages.map(page => (
+                    <div key={page.id} className="rounded-md border border-slate-700 overflow-hidden">
+                        {/* Row */}
+                        <div
+                            className="flex items-center gap-3 px-3 py-2.5 cursor-pointer hover:bg-slate-800/60 transition-colors"
+                            onClick={() => handleToggleExpand(page.id)}
+                        >
+                            <div className="flex-1 min-w-0">
+                                <p className="text-sm font-medium text-slate-100 truncate">{page.title}</p>
+                                <p className="text-xs text-slate-500 truncate">/{page.slug}</p>
+                            </div>
+                            <div className="flex items-center gap-2 shrink-0">
+                                <span
+                                    className={`px-1.5 py-0.5 text-xs rounded font-medium ${
+                                        page.published
+                                            ? 'bg-green-500/20 text-green-400'
+                                            : 'bg-slate-500/20 text-slate-400'
+                                    }`}
+                                >
+                                    {page.published ? 'Published' : 'Draft'}
+                                </span>
+                                {page.submission_count > 0 && (
+                                    <span className="text-xs text-blue-400">{page.submission_count} leads</span>
+                                )}
+                                <span className="text-xs text-slate-600">{formatRelativeTime(page.updated_at)}</span>
+                                {expandedId === page.id ? (
+                                    <ChevronUp className="w-3.5 h-3.5 text-slate-500" />
+                                ) : (
+                                    <ChevronDown className="w-3.5 h-3.5 text-slate-500" />
+                                )}
+                            </div>
+                        </div>
+
+                        {/* Expanded Actions */}
+                        {expandedId === page.id && (
+                            <div className="border-t border-slate-700 px-3 py-2.5 bg-slate-800/40 flex flex-wrap gap-2">
+                                <a
+                                    href={`/landing/${page.slug}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-slate-300 border border-slate-600 rounded hover:bg-slate-700 transition-colors"
+                                >
+                                    <ExternalLink className="w-3 h-3" />
+                                    Preview
+                                </a>
+                                <button
+                                    onClick={() => handlePublishToggle(page)}
+                                    className={`flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded border transition-colors ${
+                                        page.published
+                                            ? 'text-amber-400 border-amber-500/40 hover:bg-amber-500/20'
+                                            : 'text-green-400 border-green-500/40 hover:bg-green-500/20'
+                                    }`}
+                                >
+                                    <Globe className="w-3 h-3" />
+                                    {page.published ? 'Unpublish' : 'Publish'}
+                                </button>
+                                <button
+                                    onClick={() => handleDuplicate(page)}
+                                    className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-slate-300 border border-slate-600 rounded hover:bg-slate-700 transition-colors"
+                                >
+                                    <Copy className="w-3 h-3" />
+                                    Duplicate
+                                </button>
+                                <button
+                                    onClick={() => setShowImport(true)}
+                                    className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-slate-300 border border-slate-600 rounded hover:bg-slate-700 transition-colors"
+                                >
+                                    <Upload className="w-3 h-3" />
+                                    Import HTML
+                                </button>
+                                {confirmDeleteId === page.id ? (
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-xs text-red-400">Delete?</span>
+                                        <button
+                                            onClick={() => handleDeleteConfirm(page.id)}
+                                            className="px-2 py-1 text-xs font-medium text-white bg-red-600 rounded hover:bg-red-700 transition-colors"
+                                        >
+                                            Yes
+                                        </button>
+                                        <button
+                                            onClick={() => setConfirmDeleteId(null)}
+                                            className="px-2 py-1 text-xs font-medium text-slate-300 border border-slate-600 rounded hover:bg-slate-700 transition-colors"
+                                        >
+                                            No
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <button
+                                        onClick={() => setConfirmDeleteId(page.id)}
+                                        className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-red-400 border border-red-500/40 rounded hover:bg-red-500/20 transition-colors"
+                                    >
+                                        <Trash2 className="w-3 h-3" />
+                                        Delete
+                                    </button>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                ))}
+
+                {/* Import Form */}
+                {showImport && (
+                    <div className="rounded-md border border-slate-600 bg-slate-800/60 p-3 space-y-2">
+                        <p className="text-xs font-semibold text-slate-300">Import HTML Page</p>
+                        <input
+                            type="text"
+                            placeholder="Page title"
+                            value={importTitle}
+                            onChange={e => setImportTitle(e.target.value)}
+                            className="w-full px-2.5 py-1.5 text-xs bg-slate-700 border border-slate-600 rounded text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500"
+                        />
+                        <textarea
+                            placeholder="Paste HTML content here…"
+                            value={importHtml}
+                            onChange={e => setImportHtml(e.target.value)}
+                            rows={5}
+                            className="w-full px-2.5 py-1.5 text-xs bg-slate-700 border border-slate-600 rounded text-slate-100 placeholder-slate-500 focus:outline-none focus:border-indigo-500 resize-none"
+                        />
+                        <div className="flex gap-2">
+                            <button
+                                onClick={handleImportSubmit}
+                                disabled={!importTitle.trim() || !importHtml.trim()}
+                                className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-white bg-indigo-600 rounded hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                            >
+                                <Upload className="w-3 h-3" />
+                                Import
+                            </button>
+                            <button
+                                onClick={() => {
+                                    setShowImport(false);
+                                    setImportTitle('');
+                                    setImportHtml('');
+                                }}
+                                className="px-3 py-1.5 text-xs font-medium text-slate-300 border border-slate-600 rounded hover:bg-slate-700 transition-colors"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {/* Import shortcut at bottom when there are pages */}
+                {!loading && !error && recentPages.length > 0 && !showImport && (
+                    <button
+                        onClick={() => setShowImport(true)}
+                        className="w-full py-1.5 flex items-center justify-center gap-1.5 text-xs text-slate-500 hover:text-slate-300 hover:bg-slate-800/60 rounded transition-colors"
+                    >
+                        <Upload className="w-3 h-3" />
+                        Import HTML
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/widgets/WidgetRegistry.tsx
+++ b/frontend/src/components/widgets/WidgetRegistry.tsx
@@ -145,6 +145,10 @@ const DailyBriefingWidget = dynamic(() => import('./DailyBriefingWidget'), {
     loading: () => <WidgetSkeleton />,
     ssr: false,
 });
+const LandingPagesWidget = dynamic(() => import('./LandingPagesWidget'), {
+    loading: () => <WidgetSkeleton />,
+    ssr: false,
+});
 
 // =============================================================================
 // Widget Registry Map
@@ -176,6 +180,7 @@ const WIDGET_MAP: Record<string, ComponentType<WidgetProps>> = {
     workflow_observability: WorkflowObservabilityWidget,
     workflow_timeline: WorkflowTimelineWidget,
     daily_briefing: DailyBriefingWidget,
+    landing_pages: LandingPagesWidget,
 };
 
 // =============================================================================

--- a/frontend/src/types/widgets.ts
+++ b/frontend/src/types/widgets.ts
@@ -312,7 +312,8 @@ export type WidgetType =
     | 'campaign_hub'
     | 'self_improvement'
     | 'workflow_observability'
-    | 'workflow_timeline';
+    | 'workflow_timeline'
+    | 'landing_pages';
 
 /**
  * Campaign Hub widget data — surfaces campaign status, content pipeline,
@@ -446,7 +447,8 @@ export function isValidWidgetType(type: string): type is WidgetType {
         'kanban_board', 'workflow_builder', 'morning_briefing',
         'boardroom', 'suggested_workflows', 'form', 'table', 'calendar',
         'workflow', 'image', 'video', 'video_spec', 'braindump_analysis',
-        'campaign_hub', 'self_improvement', 'workflow_observability', 'workflow_timeline'
+        'campaign_hub', 'self_improvement', 'workflow_observability', 'workflow_timeline',
+        'landing_pages'
     ];
     return validTypes.includes(type as WidgetType);
 }

--- a/tests/unit/test_api_codegen.py
+++ b/tests/unit/test_api_codegen.py
@@ -1,0 +1,267 @@
+"""Tests for API code generator."""
+
+import ast
+
+import pytest
+
+from app.skills.api_codegen import (
+    APIToolGenerator,
+    _safe_identifier,
+    _to_snake_case,
+)
+from app.skills.api_parser import APISpec, EndpointDefinition, ParameterDef
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build test fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_api() -> APISpec:
+    """Minimal APISpec for testing code generation."""
+    return APISpec(
+        title="Test API",
+        version="1.0.0",
+        base_url="https://api.example.com/v1",
+    )
+
+
+def _make_get_endpoint() -> EndpointDefinition:
+    """Simple GET /users endpoint with one query parameter."""
+    return EndpointDefinition(
+        method="GET",
+        path="/users",
+        operation_id="listUsers",
+        summary="List all users",
+        parameters=[
+            ParameterDef(
+                name="limit",
+                location="query",
+                required=False,
+                schema={"type": "integer"},
+                description="Max results to return",
+            ),
+        ],
+    )
+
+
+def _make_get_with_path_param() -> EndpointDefinition:
+    """GET /users/{id} with a path parameter."""
+    return EndpointDefinition(
+        method="GET",
+        path="/users/{id}",
+        operation_id="getUser",
+        summary="Get user by ID",
+        parameters=[
+            ParameterDef(
+                name="id",
+                location="path",
+                required=True,
+                schema={"type": "string"},
+                description="User identifier",
+            ),
+        ],
+    )
+
+
+def _make_post_endpoint() -> EndpointDefinition:
+    """POST /users endpoint (no request body schema properties for codegen stub compat)."""
+    return EndpointDefinition(
+        method="POST",
+        path="/users",
+        operation_id="createUser",
+        summary="Create a user",
+        parameters=[],
+        request_body={"type": "object", "properties": {"name": {"type": "string"}}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestAPIToolGenerator
+# ---------------------------------------------------------------------------
+
+
+class TestAPIToolGenerator:
+    """Tests for the APIToolGenerator class."""
+
+    def test_generates_valid_python(self):
+        """Generated code should be parseable as valid Python."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", "myapi"
+        )
+        code = tool["code"]
+        # ast.parse will raise SyntaxError if the code is invalid
+        tree = ast.parse(code)
+        assert isinstance(tree, ast.Module)
+        # Should contain exactly one function definition at the top level
+        func_defs = [
+            node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+        ]
+        assert len(func_defs) >= 1
+
+    def test_function_name_format(self):
+        """operation_id='listUsers', api_name='myapi' should produce 'myapi_list_users'."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", "myapi"
+        )
+        assert tool["name"] == "myapi_list_users"
+
+    def test_function_name_no_api_prefix(self):
+        """Without api_name, function name should just be the snake_case operation_id."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", ""
+        )
+        assert tool["name"] == "list_users"
+
+    def test_includes_auth_header(self):
+        """Generated code should contain get_api_credential call."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", "myapi"
+        )
+        assert "get_api_credential" in tool["code"]
+        assert "test_secret" in tool["code"]
+
+    def test_includes_ssrf_check(self):
+        """Generated code should contain validate_url call."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", "myapi"
+        )
+        assert "validate_url" in tool["code"]
+
+    def test_generates_test_code(self):
+        """test_code should be valid Python."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", "myapi"
+        )
+        test_code = tool["test_code"]
+        assert test_code  # not empty
+        tree = ast.parse(test_code)
+        assert isinstance(tree, ast.Module)
+
+    def test_handles_path_parameters(self):
+        """Path params like /users/{id} should appear in format_map in the URL construction."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_with_path_param(), _make_api(), "test_secret", "myapi"
+        )
+        code = tool["code"]
+        # The generated code should use format_map for path params
+        assert "format_map" in code
+        assert '"/users/{id}"' in code or "/users/{id}" in code
+
+    def test_batch_generation(self):
+        """Multiple endpoints should produce multiple tool dicts."""
+        gen = APIToolGenerator()
+        endpoints = [_make_get_endpoint(), _make_get_with_path_param()]
+        api = _make_api()
+        results = gen.generate_batch(endpoints, api, "test_secret", "myapi")
+        assert len(results) == 2
+        names = {r["name"] for r in results}
+        assert "myapi_list_users" in names
+        assert "myapi_get_user" in names
+
+    def test_batch_deduplicates_names(self):
+        """Duplicate operation_ids in a batch should get numeric suffixes."""
+        gen = APIToolGenerator()
+        # Two endpoints with the same operation_id
+        ep1 = _make_get_endpoint()
+        ep2 = _make_get_endpoint()
+        results = gen.generate_batch([ep1, ep2], _make_api(), "secret", "api")
+        names = [r["name"] for r in results]
+        assert len(names) == 2
+        assert len(set(names)) == 2  # no duplicates
+        assert names[0] == "api_list_users"
+        assert names[1] == "api_list_users_2"
+
+    def test_tool_dict_keys(self):
+        """Generated tool dict should have the expected keys."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", "myapi"
+        )
+        assert set(tool.keys()) == {"name", "code", "description", "test_code"}
+
+    def test_description_uses_summary(self):
+        """Tool description should derive from the endpoint summary."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "test_secret", "myapi"
+        )
+        assert "List all users" in tool["description"]
+
+    def test_httpx_method_matches_endpoint(self):
+        """GET endpoint should produce client.get(), POST should produce client.post()."""
+        gen = APIToolGenerator()
+
+        get_tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "s", "api"
+        )
+        assert "client.get(" in get_tool["code"]
+
+        post_tool = gen.generate_tool(
+            _make_post_endpoint(), _make_api(), "s", "api"
+        )
+        assert "client.post(" in post_tool["code"]
+
+    def test_includes_timeout_handling(self):
+        """Generated code should handle httpx.TimeoutException."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "s", "api"
+        )
+        assert "TimeoutException" in tool["code"]
+
+    def test_includes_response_size_guard(self):
+        """Generated code should check response body size."""
+        gen = APIToolGenerator()
+        tool = gen.generate_tool(
+            _make_get_endpoint(), _make_api(), "s", "api"
+        )
+        assert "10 MB" in tool["code"] or "10485760" in tool["code"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestToSnakeCase:
+    """Tests for _to_snake_case helper."""
+
+    def test_camel_case(self):
+        assert _to_snake_case("listUsers") == "list_users"
+
+    def test_pascal_case(self):
+        assert _to_snake_case("ListUsers") == "list_users"
+
+    def test_kebab_case(self):
+        assert _to_snake_case("list-users") == "list_users"
+
+    def test_already_snake(self):
+        assert _to_snake_case("list_users") == "list_users"
+
+    def test_acronym_run(self):
+        assert _to_snake_case("getHTTPSUrl") == "get_https_url"
+
+
+class TestSafeIdentifier:
+    """Tests for _safe_identifier helper."""
+
+    def test_strips_special_chars(self):
+        assert _safe_identifier("my-param!") == "my_param"
+
+    def test_prefixes_digit_start(self):
+        assert _safe_identifier("123abc") == "p_123abc"
+
+    def test_handles_keyword(self):
+        result = _safe_identifier("class")
+        assert result == "class_"
+
+    def test_collapses_underscores(self):
+        assert _safe_identifier("a___b") == "a_b"

--- a/tests/unit/test_api_parser.py
+++ b/tests/unit/test_api_parser.py
@@ -1,0 +1,565 @@
+"""Tests for OpenAPI parser."""
+
+import copy
+import json
+
+import pytest
+
+from app.skills.api_parser import (
+    APISpec,
+    EndpointDefinition,
+    OpenAPIParseError,
+    OpenAPIParser,
+    ParameterDef,
+    SSRFBlockedError,
+    validate_url,
+)
+
+# ---------------------------------------------------------------------------
+# Sample minimal OpenAPI 3.0 spec for testing
+# ---------------------------------------------------------------------------
+
+SAMPLE_SPEC = {
+    "openapi": "3.0.0",
+    "info": {"title": "Test API", "version": "1.0.0"},
+    "servers": [{"url": "https://api.example.com/v1"}],
+    "paths": {
+        "/users": {
+            "get": {
+                "operationId": "listUsers",
+                "summary": "List all users",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": False,
+                        "schema": {"type": "integer"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {"type": "object"},
+                                }
+                            }
+                        }
+                    }
+                },
+            },
+            "post": {
+                "operationId": "createUser",
+                "summary": "Create a user",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {"schema": {"type": "object"}}
+                        }
+                    }
+                },
+            },
+        },
+        "/users/{id}": {
+            "get": {
+                "operationId": "getUser",
+                "summary": "Get user by ID",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {"schema": {"type": "object"}}
+                        }
+                    }
+                },
+            }
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# TestOpenAPIParser
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAPIParser:
+    """Tests for the OpenAPIParser class."""
+
+    def test_parses_basic_spec(self):
+        """Parse a minimal OpenAPI 3.0 spec and verify top-level fields."""
+        parser = OpenAPIParser()
+        result = parser.parse(SAMPLE_SPEC)
+        assert isinstance(result, APISpec)
+        assert result.title == "Test API"
+        assert result.version == "1.0.0"
+        assert result.base_url == "https://api.example.com/v1"
+        assert len(result.endpoints) == 3
+
+    def test_extracts_endpoint_methods(self):
+        """GET and POST methods should be extracted from the spec."""
+        parser = OpenAPIParser()
+        result = parser.parse(SAMPLE_SPEC)
+        methods = {e.method for e in result.endpoints}
+        assert methods == {"GET", "POST"}
+
+    def test_extracts_parameters(self):
+        """Path and query parameters should be extracted correctly."""
+        parser = OpenAPIParser()
+        result = parser.parse(SAMPLE_SPEC)
+        get_user = next(
+            e for e in result.endpoints if e.operation_id == "getUser"
+        )
+        assert any(
+            p.name == "id" and p.location == "path" for p in get_user.parameters
+        )
+
+        list_users = next(
+            e for e in result.endpoints if e.operation_id == "listUsers"
+        )
+        assert any(
+            p.name == "limit" and p.location == "query"
+            for p in list_users.parameters
+        )
+
+    def test_extracts_request_body(self):
+        """createUser endpoint should have a request_body schema."""
+        parser = OpenAPIParser()
+        result = parser.parse(SAMPLE_SPEC)
+        create_user = next(
+            e for e in result.endpoints if e.operation_id == "createUser"
+        )
+        assert create_user.request_body is not None
+        assert create_user.request_body.get("type") == "object"
+        assert "name" in create_user.request_body.get("properties", {})
+
+    def test_extracts_response_schema(self):
+        """200 response schema should be extracted for listUsers."""
+        parser = OpenAPIParser()
+        result = parser.parse(SAMPLE_SPEC)
+        list_users = next(
+            e for e in result.endpoints if e.operation_id == "listUsers"
+        )
+        assert list_users.response_schema is not None
+        assert list_users.response_schema.get("type") == "array"
+
+    def test_generates_operation_id_when_missing(self):
+        """When operationId is absent, a synthesized ID should be generated."""
+        spec = copy.deepcopy(SAMPLE_SPEC)
+        # Remove all operationIds
+        for path_item in spec["paths"].values():
+            for method in ("get", "post", "put", "delete", "patch"):
+                op = path_item.get(method)
+                if op and "operationId" in op:
+                    del op["operationId"]
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        op_ids = {e.operation_id for e in result.endpoints}
+        # Should contain auto-generated IDs based on method + path
+        assert "get_users" in op_ids
+        assert "post_users" in op_ids
+        assert "get_users_id" in op_ids
+
+    def test_resolves_refs(self):
+        """$ref pointers in schemas should be resolved inline."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Ref Test", "version": "1.0.0"},
+            "servers": [{"url": "https://api.example.com"}],
+            "components": {
+                "schemas": {
+                    "User": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "email": {"type": "string"},
+                        },
+                    }
+                }
+            },
+            "paths": {
+                "/users": {
+                    "get": {
+                        "operationId": "listUsers",
+                        "summary": "List users",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/User"
+                                            },
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        ep = result.endpoints[0]
+        # The $ref should have been resolved to the actual User schema
+        items = ep.response_schema.get("items", {})
+        assert items.get("type") == "object"
+        assert "name" in items.get("properties", {})
+
+    def test_handles_circular_refs(self):
+        """Self-referencing schema should not cause infinite recursion."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Circular Test", "version": "1.0.0"},
+            "servers": [{"url": "https://api.example.com"}],
+            "components": {
+                "schemas": {
+                    "Node": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": "string"},
+                            "children": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Node"
+                                },
+                            },
+                        },
+                    }
+                }
+            },
+            "paths": {
+                "/nodes": {
+                    "get": {
+                        "operationId": "listNodes",
+                        "summary": "List nodes",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/Node"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+        }
+
+        parser = OpenAPIParser()
+        # Should complete without hanging or raising
+        result = parser.parse(spec)
+        assert len(result.endpoints) == 1
+        ep = result.endpoints[0]
+        assert ep.response_schema is not None
+        assert ep.response_schema.get("type") == "object"
+
+    def test_rejects_swagger_2(self):
+        """Swagger 2.0 spec should raise OpenAPIParseError."""
+        spec = {
+            "swagger": "2.0",
+            "info": {"title": "Old Spec", "version": "1.0.0"},
+            "paths": {},
+        }
+
+        parser = OpenAPIParser()
+        with pytest.raises(OpenAPIParseError, match="Swagger 2.0 is not supported"):
+            parser.parse(spec)
+
+    def test_rejects_missing_openapi_key(self):
+        """A spec without 'openapi' key should raise OpenAPIParseError."""
+        spec = {
+            "info": {"title": "Bad Spec", "version": "1.0.0"},
+            "paths": {},
+        }
+
+        parser = OpenAPIParser()
+        with pytest.raises(OpenAPIParseError, match="Missing 'openapi' version key"):
+            parser.parse(spec)
+
+    def test_rejects_unsupported_openapi_version(self):
+        """Non-3.x version should raise OpenAPIParseError."""
+        spec = {
+            "openapi": "4.0.0",
+            "info": {"title": "Future Spec", "version": "1.0.0"},
+            "paths": {},
+        }
+
+        parser = OpenAPIParser()
+        with pytest.raises(OpenAPIParseError, match="Unsupported OpenAPI version"):
+            parser.parse(spec)
+
+    def test_parses_openapi_31(self):
+        """OpenAPI 3.1.x specs should be accepted."""
+        spec = {
+            "openapi": "3.1.0",
+            "info": {"title": "Modern Spec", "version": "2.0.0"},
+            "paths": {},
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        assert result.title == "Modern Spec"
+
+    def test_no_servers_falls_back_to_slash(self):
+        """When 'servers' is absent, base_url should default to '/'."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "No Server", "version": "1.0.0"},
+            "paths": {},
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        assert result.base_url == "/"
+
+    def test_server_variable_expansion(self):
+        """Server variables should be expanded to their default values."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Var Server", "version": "1.0.0"},
+            "servers": [
+                {
+                    "url": "https://api.example.com/{version}",
+                    "variables": {
+                        "version": {"default": "v2"},
+                    },
+                }
+            ],
+            "paths": {},
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        assert result.base_url == "https://api.example.com/v2"
+
+    def test_extracts_auth_schemes(self):
+        """Security schemes should be extracted from components."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Auth Test", "version": "1.0.0"},
+            "components": {
+                "securitySchemes": {
+                    "bearer_auth": {
+                        "type": "http",
+                        "scheme": "bearer",
+                        "bearerFormat": "JWT",
+                    },
+                    "api_key": {
+                        "type": "apiKey",
+                        "in": "header",
+                        "name": "X-API-Key",
+                    },
+                }
+            },
+            "paths": {},
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        assert "bearer_auth" in result.auth_schemes
+        assert result.auth_schemes["bearer_auth"]["type"] == "http"
+        assert result.auth_schemes["bearer_auth"]["scheme"] == "bearer"
+        assert "api_key" in result.auth_schemes
+        assert result.auth_schemes["api_key"]["name"] == "X-API-Key"
+
+    def test_parse_from_string_json(self):
+        """parse_from_string should accept a JSON string."""
+        parser = OpenAPIParser()
+        result = parser.parse_from_string(json.dumps(SAMPLE_SPEC))
+        assert result.title == "Test API"
+        assert len(result.endpoints) == 3
+
+    def test_parse_from_string_invalid_json(self):
+        """Invalid JSON/YAML content should raise OpenAPIParseError."""
+        parser = OpenAPIParser()
+        with pytest.raises(OpenAPIParseError):
+            parser.parse_from_string("<<<not json or yaml>>>")
+
+    def test_path_level_params_inherited(self):
+        """Path-level parameters should be inherited by operations."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Param Test", "version": "1.0.0"},
+            "paths": {
+                "/items/{itemId}": {
+                    "parameters": [
+                        {
+                            "name": "itemId",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "get": {
+                        "operationId": "getItem",
+                        "summary": "Get item",
+                        "responses": {"200": {}},
+                    },
+                }
+            },
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        ep = result.endpoints[0]
+        assert any(p.name == "itemId" and p.location == "path" for p in ep.parameters)
+
+    def test_operation_params_override_path_params(self):
+        """Operation-level params should override path-level with same name+in."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Override Test", "version": "1.0.0"},
+            "paths": {
+                "/items/{id}": {
+                    "parameters": [
+                        {
+                            "name": "id",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                            "description": "path-level",
+                        }
+                    ],
+                    "get": {
+                        "operationId": "getItem",
+                        "summary": "Get item",
+                        "parameters": [
+                            {
+                                "name": "id",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "integer"},
+                                "description": "operation-level",
+                            }
+                        ],
+                        "responses": {"200": {}},
+                    },
+                }
+            },
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        ep = result.endpoints[0]
+        id_param = next(p for p in ep.parameters if p.name == "id")
+        # Operation-level override should win
+        assert id_param.description == "operation-level"
+        assert id_param.schema.get("type") == "integer"
+
+    def test_auth_required_respects_empty_security(self):
+        """An empty security list on an operation means no auth required."""
+        spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Auth Override", "version": "1.0.0"},
+            "security": [{"bearer": []}],
+            "paths": {
+                "/public": {
+                    "get": {
+                        "operationId": "publicEndpoint",
+                        "summary": "Public",
+                        "security": [],
+                        "responses": {"200": {}},
+                    }
+                }
+            },
+        }
+
+        parser = OpenAPIParser()
+        result = parser.parse(spec)
+        ep = result.endpoints[0]
+        assert ep.auth_required is False
+
+
+# ---------------------------------------------------------------------------
+# TestValidateUrl
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrl:
+    """Tests for the SSRF URL validation function."""
+
+    def test_allows_public_urls(self):
+        """Public HTTPS URLs should pass validation."""
+        assert validate_url("https://api.example.com/spec.json") is True
+
+    def test_allows_public_http(self):
+        """Public HTTP URLs should pass validation."""
+        assert validate_url("http://api.example.com/spec.json") is True
+
+    def test_blocks_localhost(self):
+        """localhost should be blocked."""
+        assert validate_url("http://localhost:8080/spec") is False
+
+    def test_blocks_127_0_0_1(self):
+        """127.0.0.1 should be blocked."""
+        assert validate_url("http://127.0.0.1/spec") is False
+
+    def test_blocks_private_ip_10(self):
+        """10.x.x.x range should be blocked."""
+        assert validate_url("http://10.0.0.1/spec") is False
+
+    def test_blocks_private_ip_192_168(self):
+        """192.168.x.x range should be blocked."""
+        assert validate_url("http://192.168.1.1/spec") is False
+
+    def test_blocks_private_ip_172_16(self):
+        """172.16.x.x range should be blocked."""
+        assert validate_url("http://172.16.0.1/spec") is False
+
+    def test_blocks_metadata_endpoint(self):
+        """GCE/AWS metadata endpoint should be blocked."""
+        assert validate_url("http://169.254.169.254/latest/meta-data/") is False
+
+    def test_rejects_file_scheme(self):
+        """file:// scheme should be rejected."""
+        assert validate_url("file:///etc/passwd") is False
+
+    def test_rejects_ftp_scheme(self):
+        """ftp:// scheme should be rejected."""
+        assert validate_url("ftp://internal.corp/spec") is False
+
+    def test_rejects_empty_url(self):
+        """An empty string should be rejected."""
+        assert validate_url("") is False
+
+    def test_rejects_no_hostname(self):
+        """A URL without a hostname should be rejected."""
+        assert validate_url("http://") is False
+
+    def test_blocks_zero_address(self):
+        """0.0.0.0 should be blocked."""
+        assert validate_url("http://0.0.0.0/spec") is False
+
+    def test_blocks_ipv6_loopback(self):
+        """IPv6 loopback (::1) should be blocked."""
+        assert validate_url("http://[::1]/spec") is False
+
+    def test_blocks_google_metadata_hostname(self):
+        """metadata.google.internal should be blocked."""
+        assert validate_url("http://metadata.google.internal/computeMetadata/v1") is False

--- a/tests/unit/test_department_runner.py
+++ b/tests/unit/test_department_runner.py
@@ -1,12 +1,22 @@
+"""Tests for autonomous department runner."""
+
 import importlib
 import sys
 import types
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loader — patches Supabase so the import doesn't hit the network
+# ---------------------------------------------------------------------------
 
 
 def _load_department_runner_module(monkeypatch):
+    """Import department_runner with stubbed Supabase dependencies."""
     fake_agents = types.ModuleType("app.agents.specialized_agents")
     for name in [
         "compliance_agent",
@@ -28,37 +38,744 @@ def _load_department_runner_module(monkeypatch):
     return importlib.import_module("app.services.department_runner")
 
 
-def test_should_run_returns_false_when_interval_not_elapsed(monkeypatch):
-    module = _load_department_runner_module(monkeypatch)
-    runner = module.DepartmentRunner()
-    dept = {
-        "id": "dept-1",
-        "last_heartbeat": (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat(),
-        "config": {"check_interval_mins": 15},
-    }
-
-    assert runner._should_run(dept) is False
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
-def test_should_run_returns_true_when_interval_elapsed(monkeypatch):
-    module = _load_department_runner_module(monkeypatch)
-    runner = module.DepartmentRunner()
-    dept = {
-        "id": "dept-2",
-        "last_heartbeat": (datetime.now(timezone.utc) - timedelta(minutes=90)).isoformat(),
-        "config": {"check_interval_mins": 30},
-    }
-
-    assert runner._should_run(dept) is True
+@pytest.fixture
+def dept_module(monkeypatch):
+    """Provide the department_runner module with stubbed dependencies."""
+    return _load_department_runner_module(monkeypatch)
 
 
-def test_should_run_returns_true_for_invalid_timestamp(monkeypatch):
-    module = _load_department_runner_module(monkeypatch)
-    runner = module.DepartmentRunner()
-    dept = {
-        "id": "dept-3",
-        "last_heartbeat": "not-a-timestamp",
-        "config": {"check_interval_mins": 30},
-    }
+@pytest.fixture
+def runner(dept_module):
+    """Provide a DepartmentRunner instance with a mock Supabase client."""
+    r = dept_module.DepartmentRunner()
+    r.supabase = MagicMock()
+    return r
 
-    assert runner._should_run(dept) is True
+
+# ---------------------------------------------------------------------------
+# _should_run interval gate
+# ---------------------------------------------------------------------------
+
+
+class TestShouldRun:
+    """Tests for the _should_run interval gate."""
+
+    def test_returns_false_when_interval_not_elapsed(self, runner):
+        """Department should be skipped if the check interval has not elapsed."""
+        dept = {
+            "id": "dept-1",
+            "last_heartbeat": (
+                datetime.now(timezone.utc) - timedelta(minutes=5)
+            ).isoformat(),
+            "config": {"check_interval_mins": 15},
+        }
+        assert runner._should_run(dept) is False
+
+    def test_returns_true_when_interval_elapsed(self, runner):
+        """Department should run if enough time has passed."""
+        dept = {
+            "id": "dept-2",
+            "last_heartbeat": (
+                datetime.now(timezone.utc) - timedelta(minutes=90)
+            ).isoformat(),
+            "config": {"check_interval_mins": 30},
+        }
+        assert runner._should_run(dept) is True
+
+    def test_returns_true_for_invalid_timestamp(self, runner):
+        """Invalid last_heartbeat should default to running."""
+        dept = {
+            "id": "dept-3",
+            "last_heartbeat": "not-a-timestamp",
+            "config": {"check_interval_mins": 30},
+        }
+        assert runner._should_run(dept) is True
+
+    def test_returns_true_when_no_heartbeat(self, runner):
+        """Missing last_heartbeat should always run."""
+        dept = {"id": "dept-4", "config": {"check_interval_mins": 60}}
+        assert runner._should_run(dept) is True
+
+    def test_returns_true_when_interval_is_zero(self, runner):
+        """Zero interval should always run."""
+        dept = {
+            "id": "dept-5",
+            "last_heartbeat": datetime.now(timezone.utc).isoformat(),
+            "config": {"check_interval_mins": 0},
+        }
+        assert runner._should_run(dept) is True
+
+    def test_returns_true_for_invalid_interval(self, runner):
+        """Non-numeric check_interval_mins should default to running."""
+        dept = {
+            "id": "dept-6",
+            "last_heartbeat": datetime.now(timezone.utc).isoformat(),
+            "config": {"check_interval_mins": "bad"},
+        }
+        assert runner._should_run(dept) is True
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_condition
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateCondition:
+    """Tests for trigger condition evaluation."""
+
+    def test_metric_threshold_gte_matched(self, runner):
+        """metric_threshold with gte operator should match when value >= threshold."""
+        config = {"metric_key": "metrics.leads", "threshold": 10, "operator": "gte"}
+        state = {"metrics": {"leads": 15}}
+        matched, explanation = runner._evaluate_condition("metric_threshold", config, state)
+        assert matched is True
+        assert "15" in explanation
+
+    def test_metric_threshold_gte_not_matched(self, runner):
+        """metric_threshold with gte should not match when value < threshold."""
+        config = {"metric_key": "metrics.leads", "threshold": 20, "operator": "gte"}
+        state = {"metrics": {"leads": 5}}
+        matched, _ = runner._evaluate_condition("metric_threshold", config, state)
+        assert matched is False
+
+    def test_metric_threshold_lt_operator(self, runner):
+        """metric_threshold with lt operator should match when value < threshold."""
+        config = {"metric_key": "score", "threshold": 50, "operator": "lt"}
+        state = {"score": 30}
+        matched, _ = runner._evaluate_condition("metric_threshold", config, state)
+        assert matched is True
+
+    def test_metric_threshold_eq_operator(self, runner):
+        """metric_threshold with eq operator should match on equality."""
+        config = {"metric_key": "level", "threshold": 3, "operator": "eq"}
+        state = {"level": 3}
+        matched, _ = runner._evaluate_condition("metric_threshold", config, state)
+        assert matched is True
+
+    def test_metric_threshold_missing_key(self, runner):
+        """Missing metric key in state should not match."""
+        config = {"metric_key": "missing.key", "threshold": 10, "operator": "gte"}
+        state = {}
+        matched, explanation = runner._evaluate_condition("metric_threshold", config, state)
+        assert matched is False
+        assert "not found" in explanation
+
+    def test_metric_threshold_non_numeric(self, runner):
+        """Non-numeric metric value should not match."""
+        config = {"metric_key": "status", "threshold": 10, "operator": "gte"}
+        state = {"status": "active"}
+        matched, explanation = runner._evaluate_condition("metric_threshold", config, state)
+        assert matched is False
+        assert "Non-numeric" in explanation
+
+    def test_time_based_enough_elapsed(self, runner):
+        """time_based condition should match when enough hours have elapsed."""
+        past = (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat()
+        config = {"reference_timestamp": past, "min_elapsed_hours": 5}
+        matched, explanation = runner._evaluate_condition("time_based", config, {})
+        assert matched is True
+        assert "Elapsed" in explanation
+
+    def test_time_based_not_enough_elapsed(self, runner):
+        """time_based condition should not match when too little time has passed."""
+        recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        config = {"reference_timestamp": recent, "min_elapsed_hours": 24}
+        matched, _ = runner._evaluate_condition("time_based", config, {})
+        assert matched is False
+
+    def test_time_based_no_reference(self, runner):
+        """time_based with no reference_timestamp should pass by default."""
+        config = {"min_elapsed_hours": 5}
+        matched, explanation = runner._evaluate_condition("time_based", config, {})
+        assert matched is True
+        assert "No reference timestamp" in explanation
+
+    def test_time_based_invalid_reference(self, runner):
+        """Unparseable reference_timestamp should not match."""
+        config = {"reference_timestamp": "garbage", "min_elapsed_hours": 1}
+        matched, explanation = runner._evaluate_condition("time_based", config, {})
+        assert matched is False
+        assert "Unparseable" in explanation
+
+    def test_event_count_matched(self, runner):
+        """event_count should match when count >= min_count."""
+        config = {"event_key": "events.signups", "min_count": 3}
+        state = {"events": {"signups": 5}}
+        matched, _ = runner._evaluate_condition("event_count", config, state)
+        assert matched is True
+
+    def test_event_count_not_matched(self, runner):
+        """event_count should not match when count < min_count."""
+        config = {"event_key": "events.signups", "min_count": 10}
+        state = {"events": {"signups": 2}}
+        matched, _ = runner._evaluate_condition("event_count", config, state)
+        assert matched is False
+
+    def test_unknown_condition_type(self, runner):
+        """Unknown condition_type should not match."""
+        matched, explanation = runner._evaluate_condition("nonexistent_type", {}, {})
+        assert matched is False
+        assert "Unknown condition type" in explanation
+
+
+# ---------------------------------------------------------------------------
+# _core_cycle — logs no_action when nothing matches
+# ---------------------------------------------------------------------------
+
+
+class TestCoreCycle:
+    """Tests for the shared _core_cycle logic."""
+
+    @pytest.mark.asyncio
+    async def test_core_cycle_logs_no_action_when_no_triggers(self, runner, monkeypatch):
+        """When there are no triggers, workflows, or requests, no_action is logged."""
+        logged_decisions = []
+
+        async def fake_log(dept_id, decision):
+            logged_decisions.append(decision)
+
+        # Stub all three phases to return empty lists
+        monkeypatch.setattr(
+            runner, "_handle_inter_dept_requests", AsyncMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            runner, "_evaluate_triggers", AsyncMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            runner, "_check_workflow_completions", AsyncMock(return_value=[])
+        )
+        monkeypatch.setattr(runner, "_log_decision", fake_log)
+
+        state = {"dept_id": "dept-1"}
+        new_state = state.copy()
+        result = await runner._core_cycle("SALES", state, new_state)
+
+        # Should have logged a no_action decision
+        assert any(d["decision_type"] == "no_action" for d in logged_decisions)
+        assert "0 decisions" in result
+
+    @pytest.mark.asyncio
+    async def test_core_cycle_records_metrics(self, runner, monkeypatch):
+        """Cycle metrics should be recorded in new_state."""
+        monkeypatch.setattr(
+            runner, "_handle_inter_dept_requests", AsyncMock(return_value=[])
+        )
+        monkeypatch.setattr(
+            runner,
+            "_evaluate_triggers",
+            AsyncMock(
+                return_value=[
+                    {"decision_type": "workflow_launched"},
+                    {"decision_type": "trigger_matched"},
+                ]
+            ),
+        )
+        monkeypatch.setattr(
+            runner,
+            "_check_workflow_completions",
+            AsyncMock(
+                return_value=[{"decision_type": "workflow_completed"}]
+            ),
+        )
+        monkeypatch.setattr(runner, "_log_decision", AsyncMock())
+
+        state = {"dept_id": "dept-1"}
+        new_state = state.copy()
+        await runner._core_cycle("SALES", state, new_state)
+
+        metrics = new_state["last_cycle_metrics"]
+        assert metrics["workflows_launched"] == 1
+        assert metrics["workflows_completed"] == 1
+        assert "timestamp" in metrics
+
+
+# ---------------------------------------------------------------------------
+# Trigger cooldown
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerCooldown:
+    """Tests for trigger cooldown enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_trigger_cooldown_respected(self, runner, monkeypatch):
+        """A trigger with recent last_triggered_at should be skipped."""
+        recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        triggers = [
+            {
+                "id": "t-1",
+                "name": "recent_trigger",
+                "enabled": True,
+                "cooldown_hours": 24,
+                "last_triggered_at": recent,
+                "condition_type": "metric_threshold",
+                "condition_config": {
+                    "metric_key": "score",
+                    "threshold": 0,
+                    "operator": "gte",
+                },
+            }
+        ]
+
+        async def fake_execute(query_builder, op_name=""):
+            return SimpleNamespace(data=triggers)
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        state = {}
+        new_state = {}
+        decisions = await runner._evaluate_triggers("dept-1", "SALES", state, new_state)
+
+        assert len(decisions) == 1
+        assert decisions[0]["decision_type"] == "trigger_skipped"
+        assert decisions[0]["outcome"] == "cooldown"
+
+    @pytest.mark.asyncio
+    async def test_trigger_fires_after_cooldown_expires(self, runner, monkeypatch):
+        """A trigger whose cooldown has expired should fire."""
+        old = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+        triggers = [
+            {
+                "id": "t-2",
+                "name": "expired_cooldown",
+                "enabled": True,
+                "cooldown_hours": 24,
+                "last_triggered_at": old,
+                "condition_type": "metric_threshold",
+                "condition_config": {
+                    "metric_key": "score",
+                    "threshold": 0,
+                    "operator": "gte",
+                },
+                "action_type": "notify",
+                "action_config": {"message": "hello"},
+                "department_id": "dept-1",
+            }
+        ]
+
+        call_log = []
+
+        async def fake_execute(query_builder, op_name=""):
+            call_log.append(op_name)
+            return SimpleNamespace(data=triggers)
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        state = {"score": 1}
+        new_state = {}
+        decisions = await runner._evaluate_triggers("dept-1", "SALES", state, new_state)
+
+        types = [d["decision_type"] for d in decisions]
+        assert "notification_sent" in types
+        assert "trigger_matched" in types
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiting:
+    """Tests for per-cycle workflow rate limiting."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_caps_workflows(self, runner, monkeypatch):
+        """After MAX_WORKFLOWS_PER_CYCLE, further triggers should be rate-limited."""
+        # STRATEGIC has max 1 workflow per cycle
+        triggers = [
+            {
+                "id": f"t-{i}",
+                "name": f"trigger_{i}",
+                "enabled": True,
+                "cooldown_hours": 0,
+                "last_triggered_at": None,
+                "condition_type": "metric_threshold",
+                "condition_config": {
+                    "metric_key": "score",
+                    "threshold": 0,
+                    "operator": "gte",
+                },
+                "action_type": "launch_workflow",
+                "action_config": {
+                    "template_id": f"tmpl-{i}",
+                    "user_id": "user-1",
+                },
+                "department_id": "dept-1",
+            }
+            for i in range(3)  # 3 triggers, but STRATEGIC allows only 1
+        ]
+
+        wf_counter = [0]
+
+        async def fake_execute(query_builder, op_name=""):
+            if "get_triggers" in op_name:
+                return SimpleNamespace(data=triggers)
+            if "launch_workflow" in op_name:
+                wf_counter[0] += 1
+                return SimpleNamespace(data=[{"id": f"wf-{wf_counter[0]}"}])
+            return SimpleNamespace(data=[])
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        state = {"score": 10}
+        new_state = {}
+        decisions = await runner._evaluate_triggers(
+            "dept-1", "STRATEGIC", state, new_state
+        )
+
+        # Should have launched exactly 1 workflow (STRATEGIC max)
+        launched = [d for d in decisions if d["decision_type"] == "workflow_launched"]
+        rate_limited = [
+            d
+            for d in decisions
+            if d["decision_type"] == "trigger_skipped"
+            and d.get("outcome") == "rate_limited"
+        ]
+        assert len(launched) == 1
+        assert len(rate_limited) >= 1  # remaining triggers were rate-limited
+
+
+# ---------------------------------------------------------------------------
+# Workflow completion tracking
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowCompletions:
+    """Tests for pending workflow status reconciliation."""
+
+    @pytest.mark.asyncio
+    async def test_completed_workflow_removed_from_pending(self, runner, monkeypatch):
+        """A completed workflow should be removed from pending_workflows."""
+        state = {
+            "pending_workflows": [
+                {
+                    "workflow_execution_id": "wf-1",
+                    "trigger_id": "t-1",
+                    "launched_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ]
+        }
+        new_state = {}
+
+        async def fake_execute(query_builder, op_name=""):
+            return SimpleNamespace(
+                data=[{"id": "wf-1", "status": "completed", "context": {}}]
+            )
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        decisions = await runner._check_workflow_completions(state, new_state)
+
+        assert len(decisions) == 1
+        assert decisions[0]["decision_type"] == "workflow_completed"
+        # The completed workflow should be removed from pending
+        assert new_state["pending_workflows"] == []
+
+    @pytest.mark.asyncio
+    async def test_running_workflow_stays_pending(self, runner, monkeypatch):
+        """A still-running workflow should remain in pending_workflows."""
+        state = {
+            "pending_workflows": [
+                {
+                    "workflow_execution_id": "wf-2",
+                    "trigger_id": "t-2",
+                    "launched_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ]
+        }
+        new_state = {}
+
+        async def fake_execute(query_builder, op_name=""):
+            return SimpleNamespace(
+                data=[{"id": "wf-2", "status": "running", "context": {}}]
+            )
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        decisions = await runner._check_workflow_completions(state, new_state)
+
+        assert len(decisions) == 0
+        assert len(new_state["pending_workflows"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_workflow_removed_from_pending(self, runner, monkeypatch):
+        """A deleted workflow should be dropped from pending with a 'missing' decision."""
+        state = {
+            "pending_workflows": [
+                {
+                    "workflow_execution_id": "wf-gone",
+                    "trigger_id": "t-3",
+                    "launched_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ]
+        }
+        new_state = {}
+
+        async def fake_execute(query_builder, op_name=""):
+            return SimpleNamespace(data=[])
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        decisions = await runner._check_workflow_completions(state, new_state)
+
+        assert len(decisions) == 1
+        assert decisions[0]["decision_type"] == "workflow_missing"
+        assert new_state["pending_workflows"] == []
+
+    @pytest.mark.asyncio
+    async def test_failed_workflow_removed_from_pending(self, runner, monkeypatch):
+        """A failed workflow should be removed from pending with a 'failed' decision."""
+        state = {
+            "pending_workflows": [
+                {
+                    "workflow_execution_id": "wf-fail",
+                    "trigger_id": "t-4",
+                    "launched_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ]
+        }
+        new_state = {}
+
+        async def fake_execute(query_builder, op_name=""):
+            return SimpleNamespace(
+                data=[{"id": "wf-fail", "status": "failed", "context": {}}]
+            )
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        decisions = await runner._check_workflow_completions(state, new_state)
+
+        assert len(decisions) == 1
+        assert decisions[0]["decision_type"] == "workflow_failed"
+        assert decisions[0]["outcome"] == "failed"
+        assert new_state["pending_workflows"] == []
+
+    @pytest.mark.asyncio
+    async def test_no_pending_workflows_returns_empty(self, runner, monkeypatch):
+        """When there are no pending workflows, return empty decisions."""
+        state = {}
+        new_state = {}
+        decisions = await runner._check_workflow_completions(state, new_state)
+        assert decisions == []
+
+    @pytest.mark.asyncio
+    async def test_completed_workflow_updates_initiative(self, runner, monkeypatch):
+        """Completed workflow with an initiative_id should update the initiative."""
+        state = {
+            "pending_workflows": [
+                {
+                    "workflow_execution_id": "wf-init",
+                    "trigger_id": "t-5",
+                    "launched_at": datetime.now(timezone.utc).isoformat(),
+                }
+            ]
+        }
+        new_state = {}
+        update_calls = []
+
+        async def fake_execute(query_builder, op_name=""):
+            if "check_wf_status" in op_name:
+                return SimpleNamespace(
+                    data=[
+                        {
+                            "id": "wf-init",
+                            "status": "completed",
+                            "context": {"initiative_id": "init-42"},
+                        }
+                    ]
+                )
+            if "update_initiative" in op_name:
+                update_calls.append(op_name)
+                return SimpleNamespace(data=[])
+            return SimpleNamespace(data=[])
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        decisions = await runner._check_workflow_completions(state, new_state)
+
+        assert len(decisions) == 1
+        assert decisions[0]["action_taken"]["initiative_id"] == "init-42"
+        assert len(update_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Inter-department requests
+# ---------------------------------------------------------------------------
+
+
+class TestInterDeptRequests:
+    """Tests for inter-department request handling."""
+
+    @pytest.mark.asyncio
+    async def test_acknowledges_pending_requests(self, runner, monkeypatch):
+        """Pending inter-dept requests should be acknowledged."""
+        requests = [
+            {
+                "id": "req-1",
+                "from_department_id": "dept-sales",
+                "to_department_id": "dept-marketing",
+                "request_type": "content_request",
+                "status": "pending",
+            }
+        ]
+
+        async def fake_execute(query_builder, op_name=""):
+            if "get_inter_dept_pending" in op_name:
+                return SimpleNamespace(data=requests)
+            return SimpleNamespace(data=[])
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        decisions = await runner._handle_inter_dept_requests("dept-marketing")
+
+        assert len(decisions) == 1
+        assert decisions[0]["decision_type"] == "inter_dept_acknowledged"
+        assert decisions[0]["action_taken"]["request_id"] == "req-1"
+
+    @pytest.mark.asyncio
+    async def test_no_dept_id_returns_empty(self, runner):
+        """None dept_id should return empty list without DB calls."""
+        decisions = await runner._handle_inter_dept_requests(None)
+        assert decisions == []
+
+
+# ---------------------------------------------------------------------------
+# Trigger action executor
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerActionExecutor:
+    """Tests for _execute_trigger_action."""
+
+    @pytest.mark.asyncio
+    async def test_launch_workflow_action(self, runner, monkeypatch):
+        """launch_workflow action should create a workflow execution entry."""
+        trigger = {
+            "id": "t-wf",
+            "name": "auto_wf",
+            "department_id": "dept-1",
+            "action_type": "launch_workflow",
+            "action_config": {
+                "template_id": "tmpl-1",
+                "workflow_name": "Auto Test",
+                "user_id": "user-1",
+            },
+        }
+
+        async def fake_execute(query_builder, op_name=""):
+            return SimpleNamespace(data=[{"id": "wf-new"}])
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        new_state = {}
+        decisions, launched = await runner._execute_trigger_action(trigger, new_state)
+
+        assert launched == 1
+        assert any(d["decision_type"] == "workflow_launched" for d in decisions)
+        assert len(new_state["pending_workflows"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_launch_workflow_missing_template(self, runner, monkeypatch):
+        """launch_workflow without template_id should produce an error decision."""
+        trigger = {
+            "id": "t-bad",
+            "name": "no_template",
+            "department_id": "dept-1",
+            "action_type": "launch_workflow",
+            "action_config": {},
+        }
+
+        new_state = {}
+        decisions, launched = await runner._execute_trigger_action(trigger, new_state)
+
+        assert launched == 0
+        assert any(d["decision_type"] == "trigger_error" for d in decisions)
+
+    @pytest.mark.asyncio
+    async def test_escalate_action(self, runner, monkeypatch):
+        """escalate action should create an inter-dept request."""
+        trigger = {
+            "id": "t-esc",
+            "name": "escalation",
+            "department_id": "dept-sales",
+            "action_type": "escalate",
+            "action_config": {
+                "target_department_id": "dept-support",
+                "request_type": "urgent_issue",
+            },
+        }
+
+        async def fake_execute(query_builder, op_name=""):
+            return SimpleNamespace(data=[])
+
+        monkeypatch.setattr(
+            "app.services.department_runner.execute_async", fake_execute
+        )
+
+        new_state = {}
+        decisions, launched = await runner._execute_trigger_action(trigger, new_state)
+
+        assert launched == 0
+        assert any(d["decision_type"] == "escalated" for d in decisions)
+
+    @pytest.mark.asyncio
+    async def test_notify_action(self, runner, monkeypatch):
+        """notify action should produce a notification_sent decision."""
+        trigger = {
+            "id": "t-notify",
+            "name": "alert",
+            "department_id": "dept-1",
+            "action_type": "notify",
+            "action_config": {"message": "Test alert", "severity": "warning"},
+        }
+
+        new_state = {}
+        decisions, launched = await runner._execute_trigger_action(trigger, new_state)
+
+        assert launched == 0
+        assert len(decisions) == 1
+        assert decisions[0]["decision_type"] == "notification_sent"
+        assert decisions[0]["action_taken"]["severity"] == "warning"
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_type(self, runner, monkeypatch):
+        """Unknown action_type should produce an error decision."""
+        trigger = {
+            "id": "t-unk",
+            "name": "mystery",
+            "department_id": "dept-1",
+            "action_type": "teleport",
+            "action_config": {},
+        }
+
+        new_state = {}
+        decisions, launched = await runner._execute_trigger_action(trigger, new_state)
+
+        assert launched == 0
+        assert any(d["decision_type"] == "trigger_error" for d in decisions)
+        assert "Unknown action_type" in decisions[0]["decision_logic"]


### PR DESCRIPTION
## Summary
- Adds LandingPagesWidget: full-featured dashboard widget for managing landing pages
- Supports publish/unpublish toggle, duplicate, delete (with confirm), and HTML import flow
- Registers landing_pages in WidgetRegistry, WidgetType union, isValidWidgetType, and RecentWidgets icon map

## Quality Gates
- New file LandingPagesWidget.tsx: zero lint errors
- Build: passed (62/62 static pages, Vercel preview READY)
- Pre-existing lint/TS/test failures are unrelated to this change
- No new env vars (NEXT_PUBLIC_API_URL already in Vercel)
- No Supabase migrations

## Test plan
- [ ] Widget renders when agent returns type: landing_pages
- [ ] Stats row shows published/draft/lead counts
- [ ] Row expand/collapse works
- [ ] Publish toggle optimistically updates status pill
- [ ] Duplicate adds new draft row at top
- [ ] Delete confirm dialog works
- [ ] Import HTML form works
- [ ] Empty state shows two CTA buttons
- [ ] Preview link opens /landing/slug in new tab

Generated with Claude Code