### PR TITLE
fix: graceful degradation when Redis down in email triage lock

### DIFF
--- a/app/services/email_triage_worker.py
+++ b/app/services/email_triage_worker.py
@@ -293,6 +293,17 @@ class EmailTriageWorker:
             from app.services.cache import CacheService
 
             cache = CacheService()
+            # When Redis is unavailable the circuit breaker causes set_nx to
+            # return False — indistinguishable from "lock already held".  Check
+            # health first so we allow processing rather than silently skipping.
+            redis_healthy = await cache.is_healthy()
+            if not redis_healthy:
+                logger.debug(
+                    "Redis unavailable — acquiring lock optimistically for user %s",
+                    user_id,
+                )
+                return True
+
             lock_key = f"email_triage:lock:{user_id}"
             result = await cache.set_nx(lock_key, "processing", ttl=300)
             if not result:


### PR DESCRIPTION
## Summary
- Fixes bug where `EmailTriageWorker._try_acquire_lock` silently skips all email triage when Redis is unavailable
- The circuit breaker makes `set_nx()` return `False` on Redis failure, identical to 'lock already held' — now an `is_healthy()` preflight distinguishes the two cases
- When Redis is down, the lock is acquired optimistically (graceful degradation), accepting small risk of duplicate work over silently skipping all triage

## Quality Gates
- [x] Lint (ruff format — file unchanged)
- [x] Tests: 10 passed (email triage worker, product truth guards, workflow contracts)
- [x] No migration files touched
- [x] No new env vars required
- [x] No frontend changes

## Deployment Plan
- Backend: Cloud Run canary (10% -> 50% -> 100%)
- Database: No migrations
- Frontend: No changes

## Test plan
- [ ] Backend health checks pass at each canary stage
- [ ] Email triage worker processes users when Redis is unavailable
- [ ] Email triage worker correctly skips when another instance holds the lock (Redis healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)