### PR TITLE
feat: persona-specific post-onboarding — in-app checklist + email drips

### DIFF
--- a/app/services/user_onboarding_service.py
+++ b/app/services/user_onboarding_service.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 
 from pydantic import BaseModel
@@ -276,7 +276,7 @@ class UserOnboardingService:
             raise
 
     async def complete_onboarding(self, user_id: str) -> bool:
-        """Finalize onboarding."""
+        """Finalize onboarding, schedule drip emails, and init in-app checklist."""
         try:
             profile = await execute_async(
                 self.supabase.table("users_profile")
@@ -289,9 +289,10 @@ class UserOnboardingService:
             if not profile.data or not profile.data.get("business_context"):
                 raise ValueError("Cannot complete onboarding: Missing business context")
 
+            persona = profile.data.get("persona", "startup")
             update_data = {
                 "onboarding_completed": True,
-                "persona": profile.data.get("persona"),
+                "persona": persona,
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
             await execute_async(
@@ -303,10 +304,129 @@ class UserOnboardingService:
 
             await self._cache.invalidate_user_all(user_id)
             self._agent_factory.invalidate_cache(user_id)
+
+            # Schedule post-onboarding drip emails and init checklist (non-blocking)
+            try:
+                await self._schedule_post_onboarding(user_id, persona, profile.data.get("business_context", {}))
+            except Exception as e:
+                logger.warning(f"Post-onboarding setup failed for {user_id} (non-fatal): {e}")
+
             return True
         except Exception as e:
             logger.error(f"Error completing onboarding: {e}")
             raise
+
+    async def _schedule_post_onboarding(
+        self, user_id: str, persona: str, business_context: dict
+    ) -> None:
+        """Schedule drip emails and initialize in-app checklist after onboarding."""
+        now = datetime.now(timezone.utc)
+
+        # Get user email from Supabase auth
+        email = None
+        first_name = None
+        try:
+            user_response = self.supabase.auth.admin.get_user_by_id(user_id)
+            if user_response and user_response.user:
+                email = user_response.user.email
+        except Exception as e:
+            logger.warning(f"Could not fetch auth user for drip scheduling: {e}")
+
+        if not email:
+            logger.warning(f"No email found for user {user_id}, skipping drip emails")
+        else:
+            # Extract first name from business context
+            full_name = business_context.get("company_name", "")
+            role = business_context.get("role", "")
+            # Use role if it looks like a name, otherwise skip
+            if role and not any(kw in role.lower() for kw in ["ceo", "cto", "founder", "director", "manager", "vp", "head"]):
+                first_name = role.split()[0] if role else None
+
+            # Schedule 3 drip emails: Day 0, Day 3, Day 7
+            drip_schedule = [
+                {"drip_key": "welcome", "drip_day": 0, "scheduled_at": now.isoformat()},
+                {"drip_key": "tips", "drip_day": 3, "scheduled_at": (now + timedelta(days=3)).isoformat()},
+                {"drip_key": "checkin", "drip_day": 7, "scheduled_at": (now + timedelta(days=7)).isoformat()},
+            ]
+
+            drip_rows = [
+                {
+                    "user_id": user_id,
+                    "email": email,
+                    "first_name": first_name,
+                    "persona": persona,
+                    **drip,
+                }
+                for drip in drip_schedule
+            ]
+
+            try:
+                await execute_async(
+                    self.supabase.table("onboarding_drip_emails").upsert(
+                        drip_rows,
+                        on_conflict="user_id,drip_key",
+                        ignore_duplicates=True,
+                    ),
+                    op_name="onboarding.complete.schedule_drips",
+                )
+                logger.info(f"Scheduled {len(drip_rows)} drip emails for user {user_id}")
+            except Exception as e:
+                logger.warning(f"Failed to schedule drip emails for {user_id}: {e}")
+
+        # Initialize in-app onboarding checklist
+        checklist_items = self._get_checklist_items_for_persona(persona)
+        try:
+            await execute_async(
+                self.supabase.table("onboarding_checklist").upsert(
+                    {
+                        "user_id": user_id,
+                        "persona": persona,
+                        "items": checklist_items,
+                        "updated_at": now.isoformat(),
+                    },
+                    on_conflict="user_id",
+                    ignore_duplicates=True,
+                ),
+                op_name="onboarding.complete.init_checklist",
+            )
+            logger.info(f"Initialized onboarding checklist for user {user_id} ({persona})")
+        except Exception as e:
+            logger.warning(f"Failed to init checklist for {user_id}: {e}")
+
+    @staticmethod
+    def _get_checklist_items_for_persona(persona: str) -> list[dict]:
+        """Return persona-specific checklist items (matches frontend definitions)."""
+        items_map: dict[str, list[dict]] = {
+            "solopreneur": [
+                {"id": "revenue_strategy", "icon": "💰", "title": "Map your revenue strategy", "description": "Identify your best income opportunities", "completed": False},
+                {"id": "brain_dump", "icon": "🧠", "title": "Do a brain dump", "description": "Get all your ideas organized", "completed": False},
+                {"id": "weekly_plan", "icon": "📋", "title": "Plan your week", "description": "Create a focused 7-day action plan", "completed": False},
+                {"id": "first_workflow", "icon": "⚡", "title": "Run your first workflow", "description": "Automate a repetitive task", "completed": False},
+                {"id": "content_piece", "icon": "✍️", "title": "Create your first content piece", "description": "Generate a blog post or social update", "completed": False},
+            ],
+            "startup": [
+                {"id": "growth_experiment", "icon": "🚀", "title": "Design a growth experiment", "description": "Test a hypothesis to accelerate growth", "completed": False},
+                {"id": "pitch_review", "icon": "🎯", "title": "Review your pitch", "description": "Sharpen your value proposition", "completed": False},
+                {"id": "burn_rate", "icon": "📊", "title": "Check your burn rate", "description": "Understand your runway", "completed": False},
+                {"id": "team_update", "icon": "👥", "title": "Write a team update", "description": "Align your team on priorities", "completed": False},
+                {"id": "first_workflow", "icon": "⚡", "title": "Run your first workflow", "description": "Automate a repeatable process", "completed": False},
+            ],
+            "sme": [
+                {"id": "dept_health", "icon": "🏥", "title": "Run a department health check", "description": "See how each team is performing", "completed": False},
+                {"id": "process_audit", "icon": "⚙️", "title": "Audit your processes", "description": "Find bottlenecks and optimize", "completed": False},
+                {"id": "compliance_review", "icon": "🛡️", "title": "Run a compliance review", "description": "Ensure nothing falls through cracks", "completed": False},
+                {"id": "kpi_dashboard", "icon": "📊", "title": "Set up KPI tracking", "description": "Define and monitor key metrics", "completed": False},
+                {"id": "first_workflow", "icon": "⚡", "title": "Run your first workflow", "description": "Automate a department process", "completed": False},
+            ],
+            "enterprise": [
+                {"id": "stakeholder_briefing", "icon": "📋", "title": "Prepare a stakeholder briefing", "description": "Strategic update for leadership", "completed": False},
+                {"id": "risk_assessment", "icon": "⚠️", "title": "Run a risk assessment", "description": "Identify and prioritize risks", "completed": False},
+                {"id": "portfolio_review", "icon": "📈", "title": "Review initiative portfolio", "description": "Evaluate portfolio health", "completed": False},
+                {"id": "approval_workflow", "icon": "✅", "title": "Set up an approval workflow", "description": "Configure governance controls", "completed": False},
+                {"id": "first_workflow", "icon": "⚡", "title": "Run your first workflow", "description": "Automate an enterprise process", "completed": False},
+            ],
+        }
+        return items_map.get(persona, items_map["startup"])
 
     async def switch_persona(self, user_id: str, new_persona: str) -> bool:
         """Allow user to switch their persona manually."""

--- a/frontend/emails/onboarding-drip.tsx
+++ b/frontend/emails/onboarding-drip.tsx
@@ -1,0 +1,468 @@
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components';
+
+type Persona = 'solopreneur' | 'startup' | 'sme' | 'enterprise';
+type DripKey = 'welcome' | 'tips' | 'checkin';
+
+interface OnboardingDripEmailProps {
+  firstName?: string | null;
+  persona?: Persona;
+  dripKey?: DripKey;
+  dashboardUrl?: string;
+}
+
+// ─── Persona-specific content ───────────────────────────────────────────────
+
+const PERSONA_LABELS: Record<Persona, string> = {
+  solopreneur: 'Solopreneur',
+  startup: 'Startup',
+  sme: 'SME',
+  enterprise: 'Enterprise',
+};
+
+const WELCOME_CONTENT: Record<Persona, { headline: string; intro: string; actions: { icon: string; title: string; desc: string }[] }> = {
+  solopreneur: {
+    headline: 'Your AI team is ready. Here\'s your first move.',
+    intro: 'Pikar AI is now configured for lean, solo execution. No corporate overhead — just actionable AI that saves you time and grows revenue.',
+    actions: [
+      { icon: '💰', title: 'Map Your Revenue Strategy', desc: 'Identify your best income opportunities and build a growth plan' },
+      { icon: '🧠', title: 'Brain Dump Everything', desc: 'Get all your ideas organized so you can focus on what matters' },
+      { icon: '📋', title: 'Plan Your Week', desc: 'Create a focused 7-day action plan that moves the needle' },
+    ],
+  },
+  startup: {
+    headline: 'Your growth engine is live. Start experimenting.',
+    intro: 'Pikar AI is tuned for rapid validation, team alignment, and growth. Every interaction is designed to help you find product-market fit faster.',
+    actions: [
+      { icon: '🚀', title: 'Design a Growth Experiment', desc: 'Test a hypothesis quickly to learn what drives growth' },
+      { icon: '🎯', title: 'Review Your Pitch', desc: 'Sharpen your value proposition for investors and customers' },
+      { icon: '📊', title: 'Check Your Burn Rate', desc: 'Understand your runway and make smart spending decisions' },
+    ],
+  },
+  sme: {
+    headline: 'Your operations command center is ready.',
+    intro: 'Pikar AI is configured for multi-department coordination, process optimization, and operational reporting. Your AI team understands SME complexity.',
+    actions: [
+      { icon: '🏥', title: 'Department Health Check', desc: 'See how each team is performing at a glance' },
+      { icon: '⚙️', title: 'Audit Your Processes', desc: 'Find bottlenecks and optimization opportunities' },
+      { icon: '🛡️', title: 'Compliance Review', desc: 'Make sure nothing is falling through the cracks' },
+    ],
+  },
+  enterprise: {
+    headline: 'Your executive AI suite is configured.',
+    intro: 'Pikar AI is set up for governance-aware execution, portfolio visibility, and stakeholder coordination. Built for the complexity of large organizations.',
+    actions: [
+      { icon: '📋', title: 'Stakeholder Briefing', desc: 'Prepare a strategic update for leadership' },
+      { icon: '⚠️', title: 'Risk Assessment', desc: 'Identify and prioritize organizational risks' },
+      { icon: '📈', title: 'Portfolio Review', desc: 'Evaluate your initiative portfolio health' },
+    ],
+  },
+};
+
+const TIPS_CONTENT: Record<Persona, { headline: string; intro: string; tips: { icon: string; title: string; desc: string }[] }> = {
+  solopreneur: {
+    headline: '3 ways to save 10+ hours this week',
+    intro: 'You\'ve been set up for 3 days now. Here are the highest-leverage features solo operators love:',
+    tips: [
+      { icon: '⚡', title: 'Automate your weekly report', desc: 'Ask your AI to generate a business health snapshot every Monday. One prompt, zero spreadsheets.' },
+      { icon: '✍️', title: 'Repurpose your content', desc: 'Turn one blog post into 5 social posts, an email, and a LinkedIn article — automatically.' },
+      { icon: '💰', title: 'Pipeline in 60 seconds', desc: 'Say "show me my pipeline" and get instant visibility on deals, follow-ups, and revenue.' },
+    ],
+  },
+  startup: {
+    headline: 'Your first growth experiment framework',
+    intro: 'Day 3 is the perfect time to run your first structured experiment. Here\'s how your AI accelerates the cycle:',
+    tips: [
+      { icon: '🧪', title: 'Hypothesis → Test → Learn', desc: 'Ask your AI to help you structure a growth hypothesis with a clear success metric and timeline.' },
+      { icon: '📈', title: 'Track what matters', desc: 'Set up your North Star metric and supporting indicators. Your AI keeps them front and center.' },
+      { icon: '🔄', title: 'Iterate faster', desc: 'After each experiment, your AI summarizes learnings and suggests the next test to run.' },
+    ],
+  },
+  sme: {
+    headline: 'Streamline your department operations',
+    intro: 'After 3 days, your AI has context on your business. Here are features that transform how departments work together:',
+    tips: [
+      { icon: '📊', title: 'Automated KPI dashboards', desc: 'Ask for a department scorecard and get real-time performance visibility across teams.' },
+      { icon: '📝', title: 'SOP generation', desc: 'Describe any process and your AI creates a documented, shareable standard operating procedure.' },
+      { icon: '🤝', title: 'Cross-department workflows', desc: 'Set up automated handoffs between teams — no more things falling through the cracks.' },
+    ],
+  },
+  enterprise: {
+    headline: 'Governance that doesn\'t slow you down',
+    intro: 'Your AI suite is designed to add visibility and control without adding bureaucracy. Here\'s what to try next:',
+    tips: [
+      { icon: '✅', title: 'Approval workflows', desc: 'Set up multi-level approvals that route automatically based on risk, budget, and stakeholder impact.' },
+      { icon: '📋', title: 'Executive briefings', desc: 'Generate board-ready summaries of any initiative, complete with risk analysis and dependency maps.' },
+      { icon: '🔍', title: 'Audit trails', desc: 'Every AI decision and recommendation is logged with full context for compliance review.' },
+    ],
+  },
+};
+
+const CHECKIN_CONTENT: Record<Persona, { headline: string; intro: string; prompts: { icon: string; title: string; desc: string }[] }> = {
+  solopreneur: {
+    headline: 'How\'s your first week going?',
+    intro: 'You\'ve had a full week with your AI team. Here are some questions to help you get even more out of it:',
+    prompts: [
+      { icon: '📊', title: 'Review your week', desc: '"What did I accomplish this week and what should I focus on next?"' },
+      { icon: '🎯', title: 'Adjust your priorities', desc: '"Based on this week, what\'s the single most impactful thing I should do next?"' },
+      { icon: '💡', title: 'Unlock a new capability', desc: '"What features haven\'t I tried yet that would save me the most time?"' },
+    ],
+  },
+  startup: {
+    headline: 'Week 1 recap — what did you learn?',
+    intro: 'Great startups learn fast. Let your AI help you synthesize your first week of insights:',
+    prompts: [
+      { icon: '🔬', title: 'Experiment readout', desc: '"Summarize what we learned this week and what experiments we should run next."' },
+      { icon: '📈', title: 'Growth check', desc: '"How are our key metrics trending? What\'s our biggest growth lever right now?"' },
+      { icon: '👥', title: 'Team alignment', desc: '"Help me write a quick team update covering this week\'s wins and next week\'s focus."' },
+    ],
+  },
+  sme: {
+    headline: 'Your operations scorecard after 7 days',
+    intro: 'A week of data means your AI can now surface patterns. Try these to unlock operational insights:',
+    prompts: [
+      { icon: '📊', title: 'Department scorecard', desc: '"Generate a weekly operations report covering all departments."' },
+      { icon: '⚠️', title: 'Risk check', desc: '"What operational risks should I be paying attention to this week?"' },
+      { icon: '📋', title: 'Process improvements', desc: '"Based on this week, what processes should we optimize first?"' },
+    ],
+  },
+  enterprise: {
+    headline: 'Your executive dashboard is warming up',
+    intro: 'After a week of context, your AI suite is ready for strategic-level analysis. Try these power features:',
+    prompts: [
+      { icon: '📋', title: 'Strategic review', desc: '"Prepare an executive summary of all active initiatives with risk status."' },
+      { icon: '🔗', title: 'Dependency analysis', desc: '"Map the dependencies across our top initiatives and flag any blockers."' },
+      { icon: '📊', title: 'Portfolio health', desc: '"How is our initiative portfolio performing against strategic objectives?"' },
+    ],
+  },
+};
+
+// ─── Email subjects (exported for the cron route) ───────────────────────────
+
+export const DRIP_SUBJECTS: Record<DripKey, (persona: Persona) => string> = {
+  welcome: (persona) => {
+    const map: Record<Persona, string> = {
+      solopreneur: 'Your AI team is ready — here\'s your first move 🚀',
+      startup: 'Your growth engine is live — start experimenting 🧪',
+      sme: 'Your operations command center is ready ⚙️',
+      enterprise: 'Your executive AI suite is configured 📋',
+    };
+    return map[persona];
+  },
+  tips: (persona) => {
+    const map: Record<Persona, string> = {
+      solopreneur: '3 ways to save 10+ hours this week ⚡',
+      startup: 'Your first growth experiment framework 📈',
+      sme: 'Streamline your department operations 📊',
+      enterprise: 'Governance that doesn\'t slow you down ✅',
+    };
+    return map[persona];
+  },
+  checkin: (persona) => {
+    const map: Record<Persona, string> = {
+      solopreneur: 'How\'s your first week going? 📊',
+      startup: 'Week 1 recap — what did you learn? 🔬',
+      sme: 'Your operations scorecard after 7 days 📋',
+      enterprise: 'Your executive dashboard is warming up 📊',
+    };
+    return map[persona];
+  },
+};
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export default function OnboardingDripEmail({
+  firstName,
+  persona = 'startup',
+  dripKey = 'welcome',
+  dashboardUrl = 'https://pikar-ai.com/dashboard/command-center',
+}: OnboardingDripEmailProps) {
+  const displayName = firstName ?? 'there';
+  const personaLabel = PERSONA_LABELS[persona];
+
+  // Select content based on drip stage
+  const renderContent = () => {
+    if (dripKey === 'welcome') {
+      const c = WELCOME_CONTENT[persona];
+      return (
+        <>
+          <Section style={heroSection}>
+            <div style={badgeWrapper}>
+              <span style={badge}>🎉 Onboarding Complete — {personaLabel} Mode</span>
+            </div>
+            <Heading style={h1}>Hey {displayName}, {c.headline.toLowerCase()}</Heading>
+            <Text style={subtext}>{c.intro}</Text>
+          </Section>
+
+          <Section style={cardSection}>
+            <Text style={sectionLabel}>YOUR FIRST ACTIONS</Text>
+            {c.actions.map((action, i) => (
+              <div key={i} style={actionCard}>
+                <div style={actionIcon}>{action.icon}</div>
+                <div>
+                  <Text style={actionTitle}>{action.title}</Text>
+                  <Text style={actionDesc}>{action.desc}</Text>
+                </div>
+              </div>
+            ))}
+          </Section>
+        </>
+      );
+    }
+
+    if (dripKey === 'tips') {
+      const c = TIPS_CONTENT[persona];
+      return (
+        <>
+          <Section style={heroSection}>
+            <div style={badgeWrapper}>
+              <span style={badge}>💡 Day 3 — Pro Tips</span>
+            </div>
+            <Heading style={h1}>{c.headline}</Heading>
+            <Text style={subtext}>{c.intro}</Text>
+          </Section>
+
+          <Section style={cardSection}>
+            <Text style={sectionLabel}>TIPS FOR YOUR {personaLabel.toUpperCase()} WORKSPACE</Text>
+            {c.tips.map((tip, i) => (
+              <div key={i} style={actionCard}>
+                <div style={actionIcon}>{tip.icon}</div>
+                <div>
+                  <Text style={actionTitle}>{tip.title}</Text>
+                  <Text style={actionDesc}>{tip.desc}</Text>
+                </div>
+              </div>
+            ))}
+          </Section>
+        </>
+      );
+    }
+
+    // checkin
+    const c = CHECKIN_CONTENT[persona];
+    return (
+      <>
+        <Section style={heroSection}>
+          <div style={badgeWrapper}>
+            <span style={badge}>📊 Day 7 — Check-in</span>
+          </div>
+          <Heading style={h1}>{c.headline}</Heading>
+          <Text style={subtext}>{c.intro}</Text>
+        </Section>
+
+        <Section style={cardSection}>
+          <Text style={sectionLabel}>TRY THESE PROMPTS</Text>
+          {c.prompts.map((prompt, i) => (
+            <div key={i} style={actionCard}>
+              <div style={actionIcon}>{prompt.icon}</div>
+              <div>
+                <Text style={actionTitle}>{prompt.title}</Text>
+                <Text style={{ ...actionDesc, fontStyle: 'italic' }}>{prompt.desc}</Text>
+              </div>
+            </div>
+          ))}
+        </Section>
+      </>
+    );
+  };
+
+  const previewText = DRIP_SUBJECTS[dripKey](persona);
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{previewText}</Preview>
+      <Body style={body}>
+        <Container style={container}>
+          {/* Header */}
+          <Section style={header}>
+            <Text style={logo}>Pikar AI</Text>
+          </Section>
+
+          {renderContent()}
+
+          {/* CTA */}
+          <Section style={{ textAlign: 'center' as const, padding: '10px 0 30px' }}>
+            <Button style={ctaButton} href={dashboardUrl}>
+              Open Your Dashboard
+            </Button>
+          </Section>
+
+          <Hr style={divider} />
+
+          {/* Footer */}
+          <Section style={footer}>
+            <Text style={footerText}>
+              You&apos;re receiving this because you completed onboarding on Pikar AI.
+            </Text>
+            <Text style={footerText}>
+              <Link href="https://pikar-ai.com/privacy" style={footerLink}>Privacy Policy</Link>
+              {' · '}
+              <Link href="mailto:hello@pikar-ai.com" style={footerLink}>Contact Us</Link>
+            </Text>
+            <Text style={{ ...footerText, marginTop: '12px', color: '#9ca3af' }}>
+              Pikar AI · San Francisco, CA
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const body: React.CSSProperties = {
+  backgroundColor: '#f6f8f8',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+  margin: 0,
+  padding: 0,
+};
+
+const container: React.CSSProperties = {
+  maxWidth: '580px',
+  margin: '0 auto',
+  backgroundColor: '#ffffff',
+  borderRadius: '16px',
+  overflow: 'hidden',
+  marginTop: '40px',
+  marginBottom: '40px',
+  border: '1px solid #e5e7eb',
+};
+
+const header: React.CSSProperties = {
+  backgroundColor: '#0a2e2e',
+  padding: '24px 32px',
+  textAlign: 'center' as const,
+};
+
+const logo: React.CSSProperties = {
+  color: '#56ab91',
+  fontSize: '22px',
+  fontWeight: 800,
+  letterSpacing: '-0.5px',
+  margin: 0,
+};
+
+const heroSection: React.CSSProperties = {
+  padding: '32px 32px 16px',
+  textAlign: 'center' as const,
+};
+
+const badgeWrapper: React.CSSProperties = {
+  textAlign: 'center' as const,
+  marginBottom: '16px',
+};
+
+const badge: React.CSSProperties = {
+  display: 'inline-block',
+  backgroundColor: '#ecfdf5',
+  color: '#065f46',
+  fontSize: '12px',
+  fontWeight: 700,
+  padding: '6px 14px',
+  borderRadius: '9999px',
+  border: '1px solid #a7f3d0',
+};
+
+const h1: React.CSSProperties = {
+  fontSize: '24px',
+  fontWeight: 800,
+  color: '#0f172a',
+  lineHeight: '1.3',
+  margin: '0 0 12px',
+};
+
+const subtext: React.CSSProperties = {
+  fontSize: '15px',
+  color: '#64748b',
+  lineHeight: '1.6',
+  margin: '0 0 8px',
+};
+
+const cardSection: React.CSSProperties = {
+  padding: '8px 32px 24px',
+};
+
+const sectionLabel: React.CSSProperties = {
+  fontSize: '11px',
+  fontWeight: 700,
+  color: '#94a3b8',
+  letterSpacing: '1.5px',
+  margin: '0 0 16px',
+};
+
+const actionCard: React.CSSProperties = {
+  display: 'flex',
+  gap: '14px',
+  padding: '16px',
+  backgroundColor: '#f8fafc',
+  borderRadius: '12px',
+  border: '1px solid #e2e8f0',
+  marginBottom: '10px',
+};
+
+const actionIcon: React.CSSProperties = {
+  fontSize: '24px',
+  lineHeight: '1',
+  flexShrink: 0,
+  paddingTop: '2px',
+};
+
+const actionTitle: React.CSSProperties = {
+  fontSize: '14px',
+  fontWeight: 700,
+  color: '#0f172a',
+  margin: '0 0 2px',
+};
+
+const actionDesc: React.CSSProperties = {
+  fontSize: '13px',
+  color: '#64748b',
+  lineHeight: '1.5',
+  margin: 0,
+};
+
+const ctaButton: React.CSSProperties = {
+  display: 'inline-block',
+  backgroundColor: '#1a8a6e',
+  color: '#ffffff',
+  fontSize: '14px',
+  fontWeight: 700,
+  padding: '14px 32px',
+  borderRadius: '12px',
+  textDecoration: 'none',
+};
+
+const divider: React.CSSProperties = {
+  borderColor: '#e2e8f0',
+  margin: '0 32px',
+};
+
+const footer: React.CSSProperties = {
+  padding: '24px 32px',
+  textAlign: 'center' as const,
+};
+
+const footerText: React.CSSProperties = {
+  fontSize: '12px',
+  color: '#94a3b8',
+  lineHeight: '1.6',
+  margin: '0 0 4px',
+};
+
+const footerLink: React.CSSProperties = {
+  color: '#1a8a6e',
+  textDecoration: 'none',
+};

--- a/frontend/src/app/api/cron/onboarding-drips/route.ts
+++ b/frontend/src/app/api/cron/onboarding-drips/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServiceClient } from '@supabase/supabase-js';
+import { getResend, FROM_ADDRESS } from '@/lib/resend';
+import OnboardingDripEmail, { DRIP_SUBJECTS } from '../../../../../emails/onboarding-drip';
+
+type Persona = 'solopreneur' | 'startup' | 'sme' | 'enterprise';
+type DripKey = 'welcome' | 'tips' | 'checkin';
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+/**
+ * GET /api/cron/onboarding-drips
+ * Processes pending drip emails that are due.
+ * Called by Vercel Cron every hour.
+ */
+export async function GET(request: NextRequest) {
+  // Verify cron secret to prevent unauthorized access
+  if (CRON_SECRET) {
+    const authHeader = request.headers.get('authorization');
+    if (authHeader !== `Bearer ${CRON_SECRET}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return NextResponse.json({ error: 'Missing Supabase config' }, { status: 500 });
+  }
+
+  // Use service role client for cross-user access
+  const supabase = createServiceClient(supabaseUrl, serviceRoleKey);
+
+  // Find pending drips that are due
+  const { data: pendingDrips, error: fetchError } = await supabase
+    .from('onboarding_drip_emails')
+    .select('*')
+    .eq('status', 'pending')
+    .lte('scheduled_at', new Date().toISOString())
+    .order('scheduled_at', { ascending: true })
+    .limit(50); // Process in batches
+
+  if (fetchError) {
+    console.error('Drip fetch error:', fetchError);
+    return NextResponse.json({ error: 'Failed to fetch drips' }, { status: 500 });
+  }
+
+  if (!pendingDrips || pendingDrips.length === 0) {
+    return NextResponse.json({ processed: 0 });
+  }
+
+  const resend = getResend();
+  let sent = 0;
+  let failed = 0;
+
+  for (const drip of pendingDrips) {
+    const persona = drip.persona as Persona;
+    const dripKey = drip.drip_key as DripKey;
+
+    try {
+      const subject = DRIP_SUBJECTS[dripKey](persona);
+
+      await resend.emails.send(
+        {
+          from: FROM_ADDRESS,
+          to: drip.email,
+          subject,
+          react: OnboardingDripEmail({
+            firstName: drip.first_name,
+            persona,
+            dripKey,
+          }),
+        },
+        {
+          headers: {
+            'Idempotency-Key': `onboarding-drip-${drip.user_id}-${dripKey}`,
+          },
+        }
+      );
+
+      // Mark as sent
+      await supabase
+        .from('onboarding_drip_emails')
+        .update({ status: 'sent', sent_at: new Date().toISOString() })
+        .eq('id', drip.id);
+
+      sent++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      console.error(`Drip send failed for ${drip.email} (${dripKey}):`, message);
+
+      // Mark as failed with error message
+      await supabase
+        .from('onboarding_drip_emails')
+        .update({ status: 'failed', error_message: message.slice(0, 500) })
+        .eq('id', drip.id);
+
+      failed++;
+    }
+  }
+
+  return NextResponse.json({ processed: pendingDrips.length, sent, failed });
+}

--- a/frontend/src/app/api/onboarding-checklist/route.ts
+++ b/frontend/src/app/api/onboarding-checklist/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * GET /api/onboarding-checklist
+ * Returns the user's in-app onboarding checklist (items + dismissed status).
+ */
+export async function GET() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const { data, error } = await supabase
+    .from('onboarding_checklist')
+    .select('items, dismissed_at')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Checklist fetch error:', error);
+    return NextResponse.json({ error: 'Failed to fetch checklist' }, { status: 500 });
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: 'No checklist found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    items: data.items ?? [],
+    dismissed: !!data.dismissed_at,
+  });
+}
+
+/**
+ * PATCH /api/onboarding-checklist
+ * Update checklist: complete an item or dismiss the whole checklist.
+ *
+ * Body options:
+ *   { itemId: string, completed: boolean }  — mark item complete
+ *   { dismiss: true }                       — dismiss the checklist
+ */
+export async function PATCH(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const body = await request.json() as {
+    itemId?: string;
+    completed?: boolean;
+    dismiss?: boolean;
+  };
+
+  // Dismiss the entire checklist
+  if (body.dismiss) {
+    const { error } = await supabase
+      .from('onboarding_checklist')
+      .update({ dismissed_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .eq('user_id', user.id);
+
+    if (error) {
+      console.error('Checklist dismiss error:', error);
+      return NextResponse.json({ error: 'Failed to dismiss' }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  }
+
+  // Complete a specific item
+  if (body.itemId) {
+    // Fetch current items
+    const { data, error: fetchError } = await supabase
+      .from('onboarding_checklist')
+      .select('items')
+      .eq('user_id', user.id)
+      .single();
+
+    if (fetchError || !data) {
+      return NextResponse.json({ error: 'Checklist not found' }, { status: 404 });
+    }
+
+    const items = (data.items ?? []) as { id: string; completed: boolean }[];
+    const updated = items.map(item =>
+      item.id === body.itemId ? { ...item, completed: body.completed ?? true } : item
+    );
+
+    const { error: updateError } = await supabase
+      .from('onboarding_checklist')
+      .update({ items: updated, updated_at: new Date().toISOString() })
+      .eq('user_id', user.id);
+
+    if (updateError) {
+      console.error('Checklist update error:', updateError);
+      return NextResponse.json({ error: 'Failed to update' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true, items: updated });
+  }
+
+  return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+}

--- a/frontend/src/components/dashboard/OnboardingChecklist.tsx
+++ b/frontend/src/components/dashboard/OnboardingChecklist.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { CheckCircle2, Circle, X, ChevronDown, ChevronUp, Sparkles } from 'lucide-react';
+import { PersonaType } from '@/services/onboarding';
+
+// ─── Persona-specific checklist items ───────────────────────────────────────
+
+export interface ChecklistItem {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  prompt: string; // Pre-filled chat prompt when clicked
+  completed: boolean;
+}
+
+const PERSONA_CHECKLISTS: Record<PersonaType, Omit<ChecklistItem, 'completed'>[]> = {
+  solopreneur: [
+    { id: 'revenue_strategy', icon: '💰', title: 'Map your revenue strategy', description: 'Identify your best income opportunities', prompt: 'Help me map out a revenue strategy for my business. I want to identify my best income opportunities and create a plan to grow consistently.' },
+    { id: 'brain_dump', icon: '🧠', title: 'Do a brain dump', description: 'Get all your ideas organized', prompt: 'I want to do a brain dump. Help me get all my ideas, tasks, and thoughts organized so I can focus on what matters most.' },
+    { id: 'weekly_plan', icon: '📋', title: 'Plan your week', description: 'Create a focused 7-day action plan', prompt: 'Help me create a focused weekly plan. What should I prioritize this week to make the most progress on my business?' },
+    { id: 'first_workflow', icon: '⚡', title: 'Run your first workflow', description: 'Automate a repetitive task', prompt: 'What workflows can you help me automate? Show me the available workflow templates for solopreneurs.' },
+    { id: 'content_piece', icon: '✍️', title: 'Create your first content piece', description: 'Generate a blog post or social update', prompt: 'Help me create a blog post or social media content for my business. Let\'s start with a topic that will resonate with my target audience.' },
+  ],
+  startup: [
+    { id: 'growth_experiment', icon: '🚀', title: 'Design a growth experiment', description: 'Test a hypothesis to accelerate growth', prompt: 'Help me design a growth experiment. I want to identify a hypothesis we can test quickly to learn what drives growth for our startup.' },
+    { id: 'pitch_review', icon: '🎯', title: 'Review your pitch', description: 'Sharpen your value proposition', prompt: 'I want to work on my pitch. Help me sharpen our value proposition and story for investors and customers.' },
+    { id: 'burn_rate', icon: '📊', title: 'Check your burn rate', description: 'Understand your runway', prompt: 'Help me analyze our burn rate and runway. I want to understand our financial health and make smart spending decisions.' },
+    { id: 'team_update', icon: '👥', title: 'Write a team update', description: 'Align your team on priorities', prompt: 'Help me write a weekly team update. I want to communicate our wins, learnings, and priorities for next week.' },
+    { id: 'first_workflow', icon: '⚡', title: 'Run your first workflow', description: 'Automate a repeatable process', prompt: 'What workflows can you help me automate? Show me the available workflow templates for startups.' },
+  ],
+  sme: [
+    { id: 'dept_health', icon: '🏥', title: 'Run a department health check', description: 'See how each team is performing', prompt: 'Run a department health check across my organization. I want to understand how each team is performing and where we need attention.' },
+    { id: 'process_audit', icon: '⚙️', title: 'Audit your processes', description: 'Find bottlenecks and optimize', prompt: 'Help me audit our key business processes. I want to find bottlenecks, inefficiencies, and opportunities to streamline operations.' },
+    { id: 'compliance_review', icon: '🛡️', title: 'Run a compliance review', description: 'Ensure nothing falls through cracks', prompt: 'Run a compliance review for our business. I want to make sure we are meeting all regulatory requirements and nothing is falling through the cracks.' },
+    { id: 'kpi_dashboard', icon: '📊', title: 'Set up KPI tracking', description: 'Define and monitor key metrics', prompt: 'Help me set up KPI tracking for my departments. I want to define the key metrics we should monitor and create a reporting cadence.' },
+    { id: 'first_workflow', icon: '⚡', title: 'Run your first workflow', description: 'Automate a department process', prompt: 'What workflows can you help me automate? Show me the available workflow templates for SME operations.' },
+  ],
+  enterprise: [
+    { id: 'stakeholder_briefing', icon: '📋', title: 'Prepare a stakeholder briefing', description: 'Strategic update for leadership', prompt: 'Help me prepare a stakeholder briefing. I need a strategic update covering our key initiatives, risks, and progress for the leadership team.' },
+    { id: 'risk_assessment', icon: '⚠️', title: 'Run a risk assessment', description: 'Identify and prioritize risks', prompt: 'Run a comprehensive risk assessment for our organization. I want to identify, categorize, and prioritize the key risks we need to manage.' },
+    { id: 'portfolio_review', icon: '📈', title: 'Review initiative portfolio', description: 'Evaluate portfolio health', prompt: 'Help me review our initiative portfolio. I want to evaluate which initiatives are on track, which need attention, and how resources are allocated.' },
+    { id: 'approval_workflow', icon: '✅', title: 'Set up an approval workflow', description: 'Configure governance controls', prompt: 'Help me set up an approval workflow for high-impact decisions. I want governance that adds visibility without slowing us down.' },
+    { id: 'first_workflow', icon: '⚡', title: 'Run your first workflow', description: 'Automate an enterprise process', prompt: 'What workflows can you help me automate? Show me the available workflow templates for enterprise operations.' },
+  ],
+};
+
+export function getChecklistItemsForPersona(persona: PersonaType): ChecklistItem[] {
+  const templates = PERSONA_CHECKLISTS[persona] || PERSONA_CHECKLISTS.startup;
+  return templates.map(t => ({ ...t, completed: false }));
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+interface OnboardingChecklistProps {
+  persona: PersonaType;
+  userId: string;
+  onActionClick?: (prompt: string) => void;
+}
+
+export default function OnboardingChecklist({ persona, userId, onActionClick }: OnboardingChecklistProps) {
+  const [items, setItems] = useState<ChecklistItem[]>([]);
+  const [dismissed, setDismissed] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(true);
+
+  // Fetch checklist state from API
+  useEffect(() => {
+    const fetchChecklist = async () => {
+      try {
+        const res = await fetch('/api/onboarding-checklist');
+        if (res.status === 404) {
+          // No checklist exists — user completed onboarding before this feature
+          setDismissed(true);
+          return;
+        }
+        if (!res.ok) throw new Error('Failed to fetch checklist');
+        const data = await res.json() as { items: ChecklistItem[]; dismissed: boolean };
+        if (data.dismissed) {
+          setDismissed(true);
+          return;
+        }
+        setItems(data.items);
+      } catch {
+        // Silently fail — don't block dashboard
+        setDismissed(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchChecklist();
+  }, [userId]);
+
+  const completedCount = items.filter(i => i.completed).length;
+  const totalCount = items.length;
+  const progress = totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
+  const allDone = completedCount === totalCount && totalCount > 0;
+
+  const handleComplete = useCallback(async (itemId: string) => {
+    // Optimistic update
+    setItems(prev => prev.map(i => i.id === itemId ? { ...i, completed: true } : i));
+
+    try {
+      await fetch('/api/onboarding-checklist', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ itemId, completed: true }),
+      });
+    } catch {
+      // Revert on failure
+      setItems(prev => prev.map(i => i.id === itemId ? { ...i, completed: false } : i));
+    }
+  }, []);
+
+  const handleDismiss = useCallback(async () => {
+    setDismissed(true);
+    try {
+      await fetch('/api/onboarding-checklist', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dismiss: true }),
+      });
+    } catch {
+      // Don't revert — user intent is clear
+    }
+  }, []);
+
+  const handleActionClick = (item: ChecklistItem) => {
+    if (!item.completed) {
+      handleComplete(item.id);
+    }
+    onActionClick?.(item.prompt);
+  };
+
+  if (loading || dismissed) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -10 }}
+        className="mx-4 sm:mx-6 mt-6 mb-4"
+      >
+        <div className="bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center justify-between px-5 py-4 bg-gradient-to-r from-teal-50 to-emerald-50 border-b border-slate-100">
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="flex items-center gap-3 flex-1 text-left"
+            >
+              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-teal-500 to-emerald-600 flex items-center justify-center shadow-sm">
+                <Sparkles className="w-4 h-4 text-white" />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold text-slate-800">
+                  {allDone ? 'All done! You\'re set up.' : 'Get started with Pikar AI'}
+                </h3>
+                <p className="text-xs text-slate-500">
+                  {completedCount} of {totalCount} completed
+                </p>
+              </div>
+              {expanded ? <ChevronUp className="w-4 h-4 text-slate-400" /> : <ChevronDown className="w-4 h-4 text-slate-400" />}
+            </button>
+
+            <button
+              onClick={handleDismiss}
+              className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-white/60 rounded-lg transition-colors ml-2"
+              title="Dismiss checklist"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Progress bar */}
+          <div className="h-1 bg-slate-100">
+            <motion.div
+              className="h-full bg-gradient-to-r from-teal-500 to-emerald-500"
+              initial={{ width: 0 }}
+              animate={{ width: `${progress}%` }}
+              transition={{ duration: 0.5, ease: 'easeOut' }}
+            />
+          </div>
+
+          {/* Items */}
+          <AnimatePresence>
+            {expanded && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="divide-y divide-slate-100">
+                  {items.map((item) => (
+                    <button
+                      key={item.id}
+                      onClick={() => handleActionClick(item)}
+                      className={`w-full flex items-center gap-4 px-5 py-3.5 text-left transition-colors group ${
+                        item.completed
+                          ? 'bg-slate-50/50'
+                          : 'hover:bg-teal-50/50'
+                      }`}
+                    >
+                      {/* Check icon */}
+                      <div className="flex-shrink-0">
+                        {item.completed ? (
+                          <CheckCircle2 className="w-5 h-5 text-teal-500" />
+                        ) : (
+                          <Circle className="w-5 h-5 text-slate-300 group-hover:text-teal-400 transition-colors" />
+                        )}
+                      </div>
+
+                      {/* Icon */}
+                      <span className={`text-xl flex-shrink-0 ${item.completed ? 'opacity-50' : ''}`}>
+                        {item.icon}
+                      </span>
+
+                      {/* Text */}
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-sm font-semibold ${item.completed ? 'text-slate-400 line-through' : 'text-slate-700'}`}>
+                          {item.title}
+                        </p>
+                        <p className={`text-xs ${item.completed ? 'text-slate-300' : 'text-slate-500'}`}>
+                          {item.description}
+                        </p>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/dashboard/PersonaDashboardLayout.tsx
+++ b/frontend/src/components/dashboard/PersonaDashboardLayout.tsx
@@ -3,6 +3,7 @@
 import { PremiumShell } from '@/components/layout/PremiumShell';
 import { CommandCenter } from '@/components/dashboard/CommandCenter';
 import { ChatInterface, ChatHistoryItem } from '@/components/chat/ChatInterface';
+import OnboardingChecklist from '@/components/dashboard/OnboardingChecklist';
 import { PersonaType } from '@/services/onboarding';
 import { usePersona } from '@/contexts/PersonaContext';
 import { useChatSession } from '@/contexts/ChatSessionContext';
@@ -313,6 +314,17 @@ export default function PersonaDashboardLayout({
                             Switch to {currentPersona} <ArrowRight size={14} />
                         </Link>
                     </div>
+                )}
+
+                {/* In-app onboarding checklist — shown until dismissed */}
+                {ctxUserId && (
+                    <OnboardingChecklist
+                        persona={routePersona}
+                        userId={ctxUserId}
+                        onActionClick={(prompt) => {
+                            setInitialChatPrompt(prompt);
+                        }}
+                    />
                 )}
 
                 {/* Widget lists: click to open in full focus in workspace (no minimized cards) */}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -18,5 +18,11 @@
       "source": "/api/backend/:path*",
       "destination": "${NEXT_PUBLIC_API_URL}/:path*"
     }
+  ],
+  "crons": [
+    {
+      "path": "/api/cron/onboarding-drips",
+      "schedule": "0 */1 * * *"
+    }
   ]
 }

--- a/supabase/migrations/20260321100000_onboarding_drip_emails.sql
+++ b/supabase/migrations/20260321100000_onboarding_drip_emails.sql
@@ -1,0 +1,82 @@
+-- Post-onboarding drip email scheduling
+-- Tracks persona-specific email sequences sent after onboarding completes
+
+CREATE TABLE IF NOT EXISTS onboarding_drip_emails (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID NOT NULL,
+    email TEXT NOT NULL,
+    first_name TEXT,
+    persona TEXT NOT NULL CHECK (persona IN ('solopreneur', 'startup', 'sme', 'enterprise')),
+    drip_key TEXT NOT NULL CHECK (drip_key IN ('welcome', 'tips', 'checkin')),
+    drip_day INT NOT NULL,
+    scheduled_at TIMESTAMPTZ NOT NULL,
+    sent_at TIMESTAMPTZ,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'sent', 'failed', 'skipped')),
+    error_message TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id, drip_key)
+);
+
+-- Index for the cron query: find pending drips that are due
+CREATE INDEX IF NOT EXISTS idx_drip_emails_pending_due
+    ON onboarding_drip_emails (status, scheduled_at)
+    WHERE status = 'pending';
+
+-- Index for user lookup
+CREATE INDEX IF NOT EXISTS idx_drip_emails_user
+    ON onboarding_drip_emails (user_id);
+
+-- RLS
+ALTER TABLE onboarding_drip_emails ENABLE ROW LEVEL SECURITY;
+
+-- Service role can manage all drip records
+CREATE POLICY "service_role_drip_full"
+    ON onboarding_drip_emails
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+-- Users can view their own drip records
+CREATE POLICY "users_view_own_drips"
+    ON onboarding_drip_emails
+    FOR SELECT
+    TO authenticated
+    USING (user_id = auth.uid());
+
+
+-- ─── In-app onboarding checklist ────────────────────────────────────────────
+-- Tracks persona-specific guided actions shown inside the dashboard
+
+CREATE TABLE IF NOT EXISTS onboarding_checklist (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID NOT NULL,
+    persona TEXT NOT NULL CHECK (persona IN ('solopreneur', 'startup', 'sme', 'enterprise')),
+    items JSONB NOT NULL DEFAULT '[]'::jsonb,
+    dismissed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id)
+);
+
+-- Index for quick dashboard load
+CREATE INDEX IF NOT EXISTS idx_checklist_user
+    ON onboarding_checklist (user_id)
+    WHERE dismissed_at IS NULL;
+
+-- RLS
+ALTER TABLE onboarding_checklist ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_checklist_full"
+    ON onboarding_checklist
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);
+
+CREATE POLICY "users_manage_own_checklist"
+    ON onboarding_checklist
+    FOR ALL
+    TO authenticated
+    USING (user_id = auth.uid())
+    WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- In-app onboarding checklist with 5 persona-specific guided actions per persona
- Email drip re-engagement (Day 0 / Day 3 / Day 7) with persona-aware content
- Vercel cron job processes due drip emails hourly
- Backend schedules drips + checklist on onboarding completion

## New files
- `frontend/emails/onboarding-drip.tsx` — React Email template (4 personas x 3 stages)
- `frontend/src/components/dashboard/OnboardingChecklist.tsx` — dismissable checklist
- `frontend/src/app/api/onboarding-checklist/route.ts` — GET/PATCH checklist API
- `frontend/src/app/api/cron/onboarding-drips/route.ts` — cron drip processor
- `supabase/migrations/20260321100000_onboarding_drip_emails.sql` — both tables

## Modified
- `app/services/user_onboarding_service.py` — schedule drips + init checklist
- `frontend/src/components/dashboard/PersonaDashboardLayout.tsx` — wire checklist
- `frontend/vercel.json` — add hourly cron