### PR TITLE
fix(autopilot): wire canvas approve buttons to resume-autopilot

### DIFF
--- a/app/prompts/executive_instruction.txt
+++ b/app/prompts/executive_instruction.txt
@@ -152,7 +152,7 @@ You are the primary interface between the user and Pikar AI's multi-agent ecosys
 18A. **App Builder** (Canvas + Stitch): YOU OWN THIS DOMAIN — handle app-building requests YOURSELF.
    - **DO NOT DELEGATE app-building requests to OperationsOptimizationAgent or any other specialist.** App building is a first-class executive capability, not "infrastructure" or "configuration" work. The Operations agent does not have these tools and cannot help.
    - **DO NOT narrate the handoff** ("I'll hand you over to...", "switching gears..."). Just call the tool.
-   - When users ask to build an app, dashboard, website, prototype, mobile app, web app, screens, UI, or product canvas, IMMEDIATELY call `create_app_builder_launcher_widget`. Acknowledge in one short sentence — the widget itself contains the next-step button.
+   - When users ask to build an app, dashboard, website, prototype, mobile app, web app, screens, UI, or product canvas, IMMEDIATELY call `create_app_builder_canvas_widget`. Acknowledge in one short sentence — the widget embeds the live questioning wizard inside the workspace so the user stays in chat.
    - Trigger phrases include: "build an app", "create a dashboard", "design screens", "open the app builder", "open the canvas", "use stitch", "let's create the screens", "i want to build a [type] app".
 
    Tools you call directly:

--- a/app/routers/app_builder.py
+++ b/app/routers/app_builder.py
@@ -1138,16 +1138,27 @@ async def resume_autopilot(
             {"autopilot_status": "paused_screen"}
         ).eq("id", project_id).execute()
     elif current == "paused_screen":
-        if body.completed_screen_ids is None:
-            raise HTTPException(
-                status_code=400,
-                detail="completed_screen_ids required when resuming paused_screen",
+        completed_ids = body.completed_screen_ids
+        if completed_ids is None:
+            # Auto-derive from app_screens.approved so the canvas's existing
+            # "Approve" button can call resume-autopilot with an empty body.
+            screens_result = (
+                supabase.table("app_screens")
+                .select("page_slug")
+                .eq("project_id", project_id)
+                .eq("approved", True)
+                .execute()
             )
+            completed_ids = [
+                row["page_slug"]
+                for row in (screens_result.data or [])
+                if row.get("page_slug")
+            ]
         _schedule_orchestrator_task(
             project_id,
             session_id,
             "after_screen",
-            completed_screen_ids=body.completed_screen_ids,
+            completed_screen_ids=completed_ids,
         )
     elif current == "paused_ship":
         if not body.ship_target:

--- a/frontend/src/app/app-builder/[projectId]/building/page.tsx
+++ b/frontend/src/app/app-builder/[projectId]/building/page.tsx
@@ -26,6 +26,7 @@ import {
   buildAllPages,
   updateSitemap,
   advanceStage,
+  resumeAutopilot,
 } from '@/services/app-builder';
 import type {
   AppProject,
@@ -240,6 +241,13 @@ export default function BuildingPage() {
         } catch {
           // Selection failed — keep local state
         }
+        // Advance autopilot if it's parked at paused_variant. 409 means
+        // autopilot isn't running for this project — fine, ignore.
+        try {
+          await resumeAutopilot(projectId, {});
+        } catch {
+          // Not in autopilot mode; ignore.
+        }
       }
     },
     [projectId, activeScreenId],
@@ -341,6 +349,13 @@ export default function BuildingPage() {
     await approveScreen(projectId, activeScreenId);
     setIsApproved(true);
     // Note: does NOT call advanceStage — stage advancement is a separate user action
+    // Advance autopilot if parked at paused_screen; the backend auto-derives
+    // completed_screen_ids from app_screens.approved when the body is empty.
+    try {
+      await resumeAutopilot(projectId, {});
+    } catch {
+      // Not in autopilot mode; ignore.
+    }
   }, [projectId, activeScreenId]);
 
   const handleRollback = useCallback(

--- a/frontend/src/app/app-builder/[projectId]/research/page.tsx
+++ b/frontend/src/app/app-builder/[projectId]/research/page.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Search, Sparkles, Save } from 'lucide-react';
-import { startResearch, approveBrief, advanceStage } from '@/services/app-builder';
+import { startResearch, approveBrief, advanceStage, resumeAutopilot } from '@/services/app-builder';
 import { DesignBriefCard } from '@/components/app-builder/DesignBriefCard';
 import { SitemapCard } from '@/components/app-builder/SitemapCard';
 import { BuildPlanView } from '@/components/app-builder/BuildPlanView';
@@ -88,6 +88,14 @@ export default function ResearchPage() {
         raw_markdown: brief.raw_markdown,
       });
       setBuildPlan(result.build_plan);
+      // If autopilot is active and parked at paused_brief, this kicks it
+      // into the after_brief transition. 409 means autopilot isn't running
+      // for this project — that's fine, manual flow continues as before.
+      try {
+        await resumeAutopilot(projectId, {});
+      } catch {
+        // Not in autopilot mode; ignore.
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Approval failed');
     } finally {


### PR DESCRIPTION
## Summary

Two follow-ups to the autopilot ship (`feat(autopilot)` PR #12):

**1. Executive instruction — trigger now points at the canvas widget.**
Section 18A line 155 was still saying *"IMMEDIATELY call `create_app_builder_launcher_widget`"* while the tools list below it marked `create_app_builder_canvas_widget` as PREFERRED. Contradictory — Executive could pick either. Now consistent: trigger points at the canvas (embedded), launcher remains the explicit fallback.

**2. Canvas approve buttons now resume autopilot.**
The canvas''s existing `Approve & Generate Build Plan` / variant-pick / per-screen `Approve` buttons hit `approve-brief` / `select-variant` / `approve-screen` but did NOT call `resume-autopilot`. Result: orchestrator parked at `paused_brief` / `paused_variant` / `paused_screen` with no advance signal. Fix:

- `research/page.tsx` chains `resumeAutopilot({})` after `approveBrief`
- `building/page.tsx` chains `resumeAutopilot({})` after both `selectVariant` and `approveScreen`
- 409 (not in autopilot mode) is swallowed — manual flows still work for users who didn''t enter autopilot
- Backend auto-derives `completed_screen_ids` from `app_screens.approved` when `paused_screen` resume comes in with an empty body. Frontend doesn''t track the list; the DB is the source of truth.

## Test plan

- [x] `ruff check` clean on `app/routers/app_builder.py`
- [x] `tsc --noEmit` clean across the frontend
- [ ] Manual smoke: trigger via *"let''s create the screens"* → answer wizard → watch chat narration → approve brief → variant → approve screen → ship target → verify each pause auto-advances

## Risk

- Manual flow callers of `approve-brief` / `select-variant` / `approve-screen` get an extra harmless `resume-autopilot` request (returns 409 quickly). Negligible perf cost.
- Backend auto-derive query is one extra `SELECT page_slug FROM app_screens WHERE project_id=X AND approved=true` per resume — bounded by screen count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)