### PR TITLE
fix: bidirectional voice + smart-upload preview unblock + render error visibility

### DIFF
--- a/app/services/director_service.py
+++ b/app/services/director_service.py
@@ -427,17 +427,34 @@ class DirectorService:
             if renderer == "ffmpeg"
             else remotion_render_service.render_programmatic_video
         )
-        mp4_bytes, asset_id = await asyncio.to_thread(
-            render_fn,
-            props,
-            user_id,
-        )
+        try:
+            mp4_bytes, asset_id = await asyncio.to_thread(
+                render_fn,
+                props,
+                user_id,
+            )
+        except Exception as exc:
+            # Without this guard, an unhandled exception inside the render
+            # thread bypasses the diagnostics+failed-stage emit below and the
+            # frontend only sees a generic "Pro video creation failed" toast.
+            logger.exception("Render thread crashed (%s): %s", renderer, exc)
+            failure_payload: dict[str, Any] = {
+                "reason": "render_exception",
+                "render_backend": renderer,
+                "exception_type": type(exc).__name__,
+                "error": str(exc),
+            }
+            diagnostics = remotion_render_service.get_last_render_diagnostics()
+            if diagnostics:
+                failure_payload["remotion_diagnostics"] = diagnostics
+            await self._emit_progress(progress_callback, "failed", failure_payload)
+            return None
         if not mp4_bytes:
             logger.error(
                 "%s rendering failed", "FFmpeg" if renderer == "ffmpeg" else "Remotion"
             )
             remotion_diagnostics = remotion_render_service.get_last_render_diagnostics()
-            failure_payload: dict[str, Any] = {
+            failure_payload = {
                 "reason": "remotion_render_failed",
                 "render_backend": renderer,
             }

--- a/frontend/src/components/chat/ChatInterface.tsx
+++ b/frontend/src/components/chat/ChatInterface.tsx
@@ -122,6 +122,10 @@ export function ChatInterface({
   // Smart upload (Context Sniffer) state
   const [smartUploadResult, setSmartUploadResult] = useState<SmartUploadResult | null>(null);
   const [isSmartUploading, setIsSmartUploading] = useState(false);
+  // Tracks ONLY the toast's follow-up action (Add to Vault / Analyze Now). Kept
+  // separate from the global file-upload hook state so a stale upload flag
+  // can't lock the preview spinner forever.
+  const [isSmartUploadFollowupActive, setIsSmartUploadFollowupActive] = useState(false);
   // Keep the original file around so we can still use the regular upload for the agent message
   const [smartUploadFile, setSmartUploadFile] = useState<File | null>(null);
 
@@ -1181,48 +1185,58 @@ export function ChatInterface({
   const handleSmartUploadAddToVault = useCallback(async () => {
     if (!smartUploadResult || !smartUploadFile) return;
 
-    const { result, error } = await uploadFileToVault(smartUploadFile);
-    const filename = smartUploadResult.filename;
-    if (result) {
-      addMessage({
-        role: 'system',
-        text: `${filename} was saved to your Knowledge Vault.${result.processed ? ` It is now searchable with ${result.embedding_count} chunk${result.embedding_count === 1 ? '' : 's'}.` : ' It was stored, but this format could not be made searchable yet.'}`,
-      });
-    } else {
-      addMessage({
-        role: 'system',
-        text: `Could not save "${filename}" to the Knowledge Vault. Reason: ${error ?? 'Unknown error'}. Try again, or attach the file directly to your message.`,
-      });
+    setIsSmartUploadFollowupActive(true);
+    try {
+      const { result, error } = await uploadFileToVault(smartUploadFile);
+      const filename = smartUploadResult.filename;
+      if (result) {
+        addMessage({
+          role: 'system',
+          text: `${filename} was saved to your Knowledge Vault.${result.processed ? ` It is now searchable with ${result.embedding_count} chunk${result.embedding_count === 1 ? '' : 's'}.` : ' It was stored, but this format could not be made searchable yet.'}`,
+        });
+      } else {
+        addMessage({
+          role: 'system',
+          text: `Could not save "${filename}" to the Knowledge Vault. Reason: ${error ?? 'Unknown error'}. Try again, or attach the file directly to your message.`,
+        });
+      }
+    } finally {
+      setIsSmartUploadFollowupActive(false);
+      setSmartUploadResult(null);
+      setSmartUploadFile(null);
     }
-    setSmartUploadResult(null);
-    setSmartUploadFile(null);
   }, [smartUploadResult, smartUploadFile, uploadFileToVault, addMessage]);
 
   const handleSmartUploadAnalyzeNow = useCallback(async () => {
     if (!smartUploadResult || !smartUploadFile) return;
 
-    // Upload the file to get full content
-    const { result, error } = await uploadFile(smartUploadFile);
-    const filename = smartUploadResult.filename;
-    const detectedType = smartUploadResult.detected_type;
-    const summary = smartUploadResult.summary;
+    setIsSmartUploadFollowupActive(true);
+    try {
+      // Upload the file to get full content
+      const { result, error } = await uploadFile(smartUploadFile);
+      const filename = smartUploadResult.filename;
+      const detectedType = smartUploadResult.detected_type;
+      const summary = smartUploadResult.summary;
 
-    if (!result) {
-      // Full content upload failed — surface it explicitly instead of
-      // silently sending only the smart-upload preview.
-      addMessage({
-        role: 'system',
-        text: `Could not extract the full content of "${filename}". Reason: ${error ?? 'Unknown error'}. Sending the smart-upload preview only.`,
-      });
+      if (!result) {
+        // Full content upload failed — surface it explicitly instead of
+        // silently sending only the smart-upload preview.
+        addMessage({
+          role: 'system',
+          text: `Could not extract the full content of "${filename}". Reason: ${error ?? 'Unknown error'}. Sending the smart-upload preview only.`,
+        });
+      }
+
+      const message = result
+        ? `I've uploaded ${filename} (${detectedType}). Please analyze this file:\n\n---\n**File: ${result.filename}**\n${result.content}\n\n---\nPreview: ${summary}`
+        : `I've uploaded ${filename} (${detectedType}). Please analyze this file.\n\nPreview: ${summary}`;
+
+      sendMessage(message, agentMode);
+    } finally {
+      setIsSmartUploadFollowupActive(false);
+      setSmartUploadResult(null);
+      setSmartUploadFile(null);
     }
-
-    const message = result
-      ? `I've uploaded ${filename} (${detectedType}). Please analyze this file:\n\n---\n**File: ${result.filename}**\n${result.content}\n\n---\nPreview: ${summary}`
-      : `I've uploaded ${filename} (${detectedType}). Please analyze this file.\n\nPreview: ${summary}`;
-
-    sendMessage(message, agentMode);
-    setSmartUploadResult(null);
-    setSmartUploadFile(null);
   }, [smartUploadResult, smartUploadFile, uploadFile, addMessage, sendMessage, agentMode]);
 
   const handleSmartUploadDismiss = useCallback(() => {
@@ -1496,7 +1510,7 @@ export function ChatInterface({
                 onAddToVault={handleSmartUploadAddToVault}
                 onAnalyzeNow={handleSmartUploadAnalyzeNow}
                 onDismiss={handleSmartUploadDismiss}
-                isProcessing={isFileUploadUploading}
+                isProcessing={isSmartUploadFollowupActive}
               />
             )}
 

--- a/frontend/src/hooks/useVoiceSession.ts
+++ b/frontend/src/hooks/useVoiceSession.ts
@@ -848,32 +848,26 @@ export function useVoiceSession(options: UseVoiceSessionOptions = {}): UseVoiceS
                 ctx.resume().catch(() => {});
             }
 
-            // Half-duplex protection: while the agent is speaking, don't
-            // forward mic audio back. Prevents the model from hearing its
-            // own voice and stalling. Once turn_complete arrives from the
-            // server and playback drains, this gate releases.
-            const recentRemoteActivity = !remoteTurnCompleteRef.current
-                && (Date.now() - lastRemoteActivityAtRef.current) <= REMOTE_TURN_ACTIVITY_TAIL_MS;
-            const agentAudioActive = isPlayingRef.current
-                || recentRemoteActivity
-                || playbackQueueRef.current.length > 0
-                || Boolean(pendingTurnDelayRef.current);
-            if (agentAudioActive) {
-                return;
-            }
-
-            // The Gemini Live API has its own server-side VAD
-            // (automatic_activity_detection) which is the spec-correct
-            // source of truth for speech start/end. Forwarding ALL audio
-            // continuously lets the server make that decision. The earlier
-            // approach of doing local-RMS gating dropped quiet speech
-            // before it could reach the model — quiet voices, low gain
-            // mics, or far-from-mic users would never trigger the server
-            // VAD because the bytes never arrived. We also no longer send
-            // `audio_stream_end` per-utterance: per the spec that signals
-            // "mic was turned off"; using it as an utterance boundary
-            // confuses the turn-detection on the model side. We send it
-            // exactly once when the user explicitly ends the session.
+            // Forward ALL mic audio continuously, even while the agent is
+            // speaking. Gemini Live's server-side VAD needs continuous
+            // input to detect user interruption — that's how bidirectional
+            // conversation works. The earlier half-duplex gate here
+            // prevented the user from EVER interrupting the agent: any
+            // bytes spoken during agent playback were dropped client-side
+            // and the server never saw them, so server VAD never fired
+            // and the model monologued indefinitely.
+            //
+            // Echo/feedback prevention is handled by the browser's built-in
+            // AEC (echoCancellation: true on the getUserMedia constraints
+            // above). For the rare audio configs where AEC underperforms
+            // (e.g., some Bluetooth setups), the model treating bleed-through
+            // as a soft interruption is a far better failure mode than the
+            // gate's "interruption never works" failure mode.
+            //
+            // We also no longer send `audio_stream_end` per-utterance: per
+            // the spec that signals "mic was turned off"; using it as an
+            // utterance boundary confuses turn-detection on the model
+            // side. We send it exactly once when the user ends the session.
             const pcm16 = float32ToPcm16(inputData, ctx.sampleRate, MIC_SAMPLE_RATE);
             const uint8 = new Uint8Array(pcm16.buffer);
             let binary = '';

--- a/frontend/src/types/api.generated.ts
+++ b/frontend/src/types/api.generated.ts
@@ -6344,7 +6344,7 @@ export interface paths {
          * @description Upload a document, image, or video to the agent knowledge base.
          *
          *     Routes the file to the appropriate processing pipeline based on MIME type:
-         *     - PDF / DOCX / text files → process_document (returns 200)
+         *     - PDF / DOCX / XLSX / text files → process_document (returns 200)
          *     - Image files             → process_image (returns 200)
          *     - Video files             → process_video (returns 202, background processing)
          *


### PR DESCRIPTION
## Summary

Three independent UX bugs reported in production. Each is a **state-binding** bug — prior fix attempts hardened the plumbing (network retries, server VAD, upload proxy) while the consumers were wired to wrong/stale state.

| Bug | Root cause | File |
|---|---|---|
| Brain-dump agent monologues, can't interrupt | Client-side half-duplex mic gate dropped all user audio while agent spoke; server VAD never saw user speech, so interruption was physically impossible | `frontend/src/hooks/useVoiceSession.ts` |
| Document upload preview stuck on infinity spinner | `SmartUploadToast` `isProcessing` was wired to global `isFileUploadUploading` hook flag; a stale `true` from a prior aborted upload locked the toast forever | `frontend/src/components/chat/ChatInterface.tsx` |
| Video render fails with generic toast, no actionable detail | `asyncio.to_thread(render_fn, ...)` had no try/except; Python exceptions inside the render thread bypassed the diagnostics emit and the failed-stage progress event | `app/services/director_service.py` |

## Why now

- 4 prior commits tried to fix the upload bug at the network layer (`08304321`, `0edf6054`, `f58e2541`); none touched the UI state binding. This is the root.
- 1 prior commit (`e3a1536a`) added `waitingForInput` so the voice gate would *eventually* open. But the user wants to interrupt mid-sentence — which the gate forbade. Gate removal is the architectural fix.
- The director visibility gap means we currently can't tell whether render failures are `cli_not_found`, `render_disabled`, missing Chromium, or a Python exception — they all surface as the same generic toast.

## Test plan

- [ ] **Voice**: start brain-dump, talk over the agent mid-sentence — agent should stop and respond within ~700ms (Gemini Live `silence_duration_ms`)
- [ ] **Upload**: drop a document into chat; preview toast should render with enabled buttons and no spinner; clicking a button should show spinner only during that action and clear cleanly
- [ ] **Render**: trigger a video; if it fails, the toast/progress event should now name the actual `reason` (e.g., `render_exception`, `cli_not_found`) instead of generic "video rendering process failed"

## Quality gates

**My files pass:**
- ruff check + format clean on `director_service.py`
- tsc --noEmit clean on the 2 frontend files
- 35/35 director + voice + remotion unit tests pass
- ESLint scoped to my edit ranges in `ChatInterface.tsx` (lines ~130, 1180-1240) and `useVoiceSession.ts` (lines 851-870) is clean

**Pre-existing repo tech debt (NOT introduced by this PR, flagged for awareness):**
- 692 ruff errors across `app/` (mostly RUF013 implicit Optional, F841 unused assignments, RUF022 __all__ sort)
- 295 frontend ESLint problems (mostly `@typescript-eslint/no-explicit-any` in `services/workflows.ts` and friends)
- 5 pytest collection errors on unrelated test files (`test_byok_service`, `test_gmail_reader`, `test_tools` etc.)
- 4 ChatInterface tests fail because the test setup doesn't wrap in `SessionControlProvider` (verified pre-existing — `useSessionControl` was at HEAD line 110 before this PR)
- `ty` and `codespell` not installed on the deploy workstation

## Risk

| Fix | Risk if wrong | Recovery |
|---|---|---|
| Director try/except | Pure additive (failure modes get more descriptive) | Revert |
| Upload state rebinding | Spinner state misbehaves; doesn't break uploads | Revert |
| Voice gate removal | If browser AEC underperforms on a user's audio config, model may briefly hear itself | Revert + redeploy |

🤖 Generated with [Claude Code](https://claude.com/claude-code)