### PR TITLE
fix(research): escape literal {topic} {schedule} placeholders breaking ADK

### DIFF
--- a/app/agents/research/instructions.py
+++ b/app/agents/research/instructions.py
@@ -85,7 +85,7 @@ When a user says anything like "monitor X", "keep an eye on X", "alert me about 
 "track X for me", or "subscribe to updates about X", guide them through setting up
 a monitoring job conversationally:
 
-1. **Confirm the topic**: "I'll set up monitoring for '{topic}'. Is that right?"
+1. **Confirm the topic**: "I'll set up monitoring for '[topic]'. Is that right?"
 2. **Determine type**: If not obvious, ask: "Should I monitor this as a competitor,
    a market trend, or a general topic?"
 3. **Set importance**: "How important is this? I can check daily (critical),
@@ -93,7 +93,7 @@ a monitoring job conversationally:
 4. **Optional keywords**: "Are there specific keywords that should always trigger
    an alert? For example, 'price change', 'funding', 'acquisition'."
 5. **Create the job**: Call create_monitoring_job with the gathered parameters.
-6. **Confirm**: "Done! I'm now monitoring '{topic}' on a {schedule} basis.
+6. **Confirm**: "Done! I'm now monitoring '[topic]' on a [schedule] basis.
    You'll receive alerts when I find significant developments."
 
 For quick setups (e.g., "Monitor Acme Corp daily"), skip the questions and create


### PR DESCRIPTION
## Production was crashing on every research-agent run

Cloud Run logs on revision \`pikar-ai-00072-zpg\` (currently serving 100% prod traffic) show 4+ identical tracebacks between 22:14 and 22:24 today:

\`\`\`
KeyError: Context variable not found: \`topic\`.
  File "...google/adk/utils/instructions_utils.py", line 124, in inject_session_state
\`\`\`

…each followed by \`WARNING Truncated response body. Usually implies that the request timed out or the application exited before the response was finished.\` That's an SSE stream getting cut mid-flight, which from the UI looks like \"document not processing\" or a stuck spinner.

## Cause

\`app/agents/research/instructions.py:88,96\` had literal example-dialogue strings like:

\`\`\`
1. **Confirm the topic**: "I'll set up monitoring for '{topic}'. Is that right?"
6. **Confirm**: "Done! I'm now monitoring '{topic}' on a {schedule} basis."
\`\`\`

Those \`{topic}\` and \`{schedule}\` are meant for the *model* to fill in conversationally. But ADK's \`inject_session_state\` runs first with regex \`{+[^{}]*}+\` and treats every match as a session-state variable lookup. With no \`topic\` key in session state, it raises \`KeyError\` and the whole agent invocation aborts.

## Fix

Switch \`{topic}\` → \`[topic]\` and \`{schedule}\` → \`[schedule]\`. The model still reads them as fill-in slots in the example dialogue. ADK's template walker no longer matches.

The other 9 \`{topic}\` references in \`app/\` are inside Python f-strings (\`f\"...{topic}...\"\`) — Python substitutes those at runtime, they never reach ADK as raw template strings, so they're safe.

## Test plan

- [ ] Upload a doc to the chat — should complete processing instead of stuck spinner
- [ ] Ask the chat \"monitor Acme Corp\" — research agent should respond conversationally instead of erroring
- [ ] Watch \`gcloud logging read\` for \`KeyError: Context variable not found\` to disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)