### PR TITLE
fix(research): escape {topic}/{schedule} literals breaking ADK instruction injection

### DIFF
--- a/app/agents/research/instructions.py
+++ b/app/agents/research/instructions.py
@@ -85,7 +85,7 @@ When a user says anything like "monitor X", "keep an eye on X", "alert me about 
 "track X for me", or "subscribe to updates about X", guide them through setting up
 a monitoring job conversationally:
 
-1. **Confirm the topic**: "I'll set up monitoring for '{topic}'. Is that right?"
+1. **Confirm the topic**: "I'll set up monitoring for '[topic]'. Is that right?"
 2. **Determine type**: If not obvious, ask: "Should I monitor this as a competitor,
    a market trend, or a general topic?"
 3. **Set importance**: "How important is this? I can check daily (critical),
@@ -93,7 +93,7 @@ a monitoring job conversationally:
 4. **Optional keywords**: "Are there specific keywords that should always trigger
    an alert? For example, 'price change', 'funding', 'acquisition'."
 5. **Create the job**: Call create_monitoring_job with the gathered parameters.
-6. **Confirm**: "Done! I'm now monitoring '{topic}' on a {schedule} basis.
+6. **Confirm**: "Done! I'm now monitoring '[topic]' on a [schedule] basis.
    You'll receive alerts when I find significant developments."
 
 For quick setups (e.g., "Monitor Acme Corp daily"), skip the questions and create


### PR DESCRIPTION
Re-shipping the fix from PR #16 on a fresh branch off current main (PR #16 went stale when bd1ccd5d landed in parallel).

## What's broken on production right now

\`pikar-ai-00072-zpg\` logs show repeated:
\`\`\`
KeyError: Context variable not found: \`topic\`.
  File ".../google/adk/utils/instructions_utils.py", line 124, in inject_session_state
\`\`\`
…each followed by \`WARNING Truncated response body\`. That's an SSE stream cut mid-flight, which from the UI looks like \"document not processing\" or stuck spinner.

## Cause + fix

\`app/agents/research/instructions.py:88,96\` had literal example dialogue with \`{topic}\` and \`{schedule}\`. ADK's \`inject_session_state\` regex \`{+[^{}]*}+\` treats those as session-state lookups and raises \`KeyError\` when they aren't present.

Switch to \`[topic]\` and \`[schedule]\`. The model still reads them as fill-in placeholders in the example dialogue. The other 9 \`{topic}\` references in \`app/\` are inside Python f-strings — they're substituted at runtime and never reach ADK, so they're safe.

## Test plan

- [ ] After merge + deploy, watch \`gcloud logging read\` for \`KeyError: Context variable not found\` to disappear
- [ ] Upload a doc to chat — should complete instead of hanging
- [ ] Ask chat \"monitor Acme Corp\" — research agent responds conversationally instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)