### PR TITLE
feat(auth): expand Supabase Google sign-in scopes to full Workspace set

### DIFF
--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -72,7 +72,24 @@ export const signInWithGoogle = async () => {
     provider: 'google',
     options: {
       redirectTo: `${window.location.origin}/auth/callback`,
-      scopes: 'email profile https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.modify https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/calendar',
+      // Path A scopes — kept in sync with the Path B canonical list at
+      // app/config/integration_providers.py:206-215 so a user who signs in
+      // with Google gets full Workspace access without needing the separate
+      // "Connect Google Workspace" Phase 102 button. Adding new scopes here
+      // requires existing users to re-consent on next sign-in (the
+      // `prompt: consent` flag below already forces that).
+      scopes: [
+        'email',
+        'profile',
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.modify',
+        'https://www.googleapis.com/auth/gmail.send',
+        'https://www.googleapis.com/auth/calendar',
+        'https://www.googleapis.com/auth/documents',
+        'https://www.googleapis.com/auth/spreadsheets',
+        'https://www.googleapis.com/auth/drive.file',
+        'https://www.googleapis.com/auth/forms.body',
+      ].join(' '),
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',


### PR DESCRIPTION
## Summary
- Aligns Path A (Supabase Google sign-in) scopes with Path B (Phase 102 canonical list at \`app/config/integration_providers.py:206-215\`).
- Adds \`documents\`, \`spreadsheets\`, \`drive.file\`, \`forms.body\` to the four existing Gmail + Calendar scopes.
- A user who signs in with Google now gets full Workspace access without needing the separate Connect button.

## Sequencing
- Required prerequisite (already confirmed done): the four new scopes are added to the OAuth consent screen for project \`pikar-ai-project\`.
- \`prompt: 'consent'\` already forces re-consent on every Google sign-in, so existing users will be prompted to grant the new scopes on next login.

## Test plan
- [ ] Confirm Vercel deploys after merge
- [ ] Sign out + sign in with Google; verify the consent screen lists Docs, Sheets, Drive (limited), and Forms
- [ ] Hit \`/api/configuration/google-workspace-status\`; expect \`connected: true\` with \`connection_source: legacy_refresh_token\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)