### PR TITLE
fix(frontend): surface Team/Workflows/Departments/Governance + Admin in sidebar

### DIFF
--- a/frontend/src/components/layout/PremiumShell.tsx
+++ b/frontend/src/components/layout/PremiumShell.tsx
@@ -12,6 +12,7 @@ import {
     MessageCircle,
     Layers,
     Lock,
+    ShieldAlert,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
@@ -21,8 +22,9 @@ import { getPersonaNavItems } from './personaNavConfig';
 import { SubscriptionBadge } from '@/components/billing/SubscriptionBadge';
 import { UpgradeGateModal } from './UpgradeGateModal';
 import { UPGRADE_GATE_EVENT, type UpgradeGateEvent } from '@/services/api';
-import { isFeatureAllowed, FEATURE_ACCESS, type PersonaTier } from '@/config/featureGating';
-import { useSubscription } from '@/contexts/SubscriptionContext';
+import { isFeatureAllowed, FEATURE_ACCESS } from '@/config/featureGating';
+import { useEffectiveTier } from '@/hooks/useEffectiveTier';
+import { useAdminAccess } from '@/hooks/useAdminAccess';
 import { KpiHeader } from '@/components/layout/KpiHeader';
 import { signOut } from '@/services/auth';
 
@@ -66,18 +68,15 @@ export function PremiumShell({
     }
     const navItems = useMemo(() => getPersonaNavItems(currentPersona as 'solopreneur' | 'startup' | 'sme' | 'enterprise' | null), [currentPersona]);
 
-    // Resolve the user's subscription tier for feature gating.
-    // PremiumShell can render outside SubscriptionProvider (e.g., admin pages).
-    // We mirror the established usePersona() try/catch pattern in this file.
-    // 'free' users are treated as 'solopreneur' for gating (same access level).
-    let userTier: PersonaTier = 'solopreneur';
-    try {
-        const sub = useSubscription();
-        const rawTier = sub.tier;
-        userTier = (rawTier === 'free' ? 'solopreneur' : rawTier) as PersonaTier;
-    } catch {
-        // Outside SubscriptionProvider — default tier remains 'solopreneur'.
-    }
+    // Resolve the user's effective tier for feature gating. The hook prefers
+    // subscription.tier (with 'free' mapped to 'solopreneur') and falls back
+    // to persona when the SubscriptionProvider is not mounted. Replaces the
+    // previous inline logic that diverged from useFeatureGate.
+    const { tier: userTier } = useEffectiveTier();
+
+    // Admin role check — separate from tier gating. Renders the "Admin Panel"
+    // sidebar entry only for users whose backend role check passes.
+    const { isAdmin } = useAdminAccess();
 
     // Listen for upgrade-gate events dispatched by fetchWithAuth on 403 responses.
     useEffect(() => {
@@ -249,6 +248,15 @@ export function PremiumShell({
                             />
                         );
                     })}
+                    {isAdmin && (
+                        <NavItem
+                            href="/admin"
+                            icon={<ShieldAlert size={20} />}
+                            label="Admin Panel"
+                            collapsed={navCollapsed}
+                            active={pathname?.startsWith('/admin')}
+                        />
+                    )}
                 </nav>
 
                 {/* Footer / Collapse Toggle */}
@@ -336,6 +344,15 @@ export function PremiumShell({
                                 />
                             );
                         })}
+                        {isAdmin && (
+                            <NavItem
+                                href="/admin"
+                                icon={<ShieldAlert size={20} />}
+                                label="Admin Panel"
+                                collapsed={false}
+                                active={pathname?.startsWith('/admin')}
+                            />
+                        )}
                     </nav>
 
                     <div className="shrink-0 p-3 border-t border-teal-800/60">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,18 +3,19 @@
 import React, { useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { Lock, LogOut } from 'lucide-react'
+import { Lock, LogOut, ShieldAlert } from 'lucide-react'
 import { SessionList } from '../chat/SessionList'
 import { RecentWidgets } from './RecentWidgets'
 import { MAIN_INTERFACE_ROUTE } from './sidebarNav'
 import { usePendingApprovals } from '@/hooks/usePendingApprovals'
 import { usePersona } from '@/contexts/PersonaContext'
+import { useAdminAccess } from '@/hooks/useAdminAccess'
+import { useEffectiveTier } from '@/hooks/useEffectiveTier'
 import { getPersonaNavItems } from './personaNavConfig'
 import {
   getFeatureKeyForRoute,
   isFeatureAllowed,
   type FeatureKey,
-  type PersonaTier,
 } from '@/config/featureGating'
 import { UpgradePrompt } from '@/components/ui/UpgradePrompt'
 import { signOut } from '@/services/auth'
@@ -27,7 +28,8 @@ export function Sidebar({ className }: SidebarProps) {
   const router = useRouter();
   const { count: pendingCount } = usePendingApprovals();
 
-  // Persona-aware nav ordering
+  // Persona-aware nav ordering — persona drives the *visual* ordering of
+  // items in the sidebar, distinct from tier gating which controls locks.
   let currentPersona: string | null = null;
   try {
     const ctx = usePersona();
@@ -36,6 +38,16 @@ export function Sidebar({ className }: SidebarProps) {
     // Fallback to default ordering
   }
   const navItems = useMemo(() => getPersonaNavItems(currentPersona as 'solopreneur' | 'startup' | 'sme' | 'enterprise' | null), [currentPersona]);
+
+  // Effective tier drives the lock-icon / upgrade-popover decisions. Resolved
+  // via the centralized hook so this surface agrees with PremiumShell and
+  // useFeatureGate (previously this file used persona directly, which could
+  // disagree with subscription.tier for free-plan users).
+  const { tier: userTier } = useEffectiveTier();
+
+  // Admin role check — separate from tier gating. Renders an "Admin Panel"
+  // nav entry only when the backend role check passes.
+  const { isAdmin } = useAdminAccess();
 
   // Track which locked nav item's upgrade popover is open
   const [lockedFeaturePopover, setLockedFeaturePopover] = useState<FeatureKey | null>(null);
@@ -75,12 +87,11 @@ export function Sidebar({ className }: SidebarProps) {
           const Icon = item.icon
           const isApprovals = item.label === 'Approvals';
 
-          // Determine if this nav item is gated
+          // Determine if this nav item is gated. Uses the resolved effective
+          // tier (subscription-canonical) rather than persona directly.
           const featureKey = getFeatureKeyForRoute(item.href);
           const isLocked =
-            featureKey !== null &&
-            currentPersona !== null &&
-            !isFeatureAllowed(featureKey, currentPersona as PersonaTier);
+            featureKey !== null && !isFeatureAllowed(featureKey, userTier);
 
           if (isLocked && featureKey !== null) {
             const isPopoverOpen = lockedFeaturePopover === featureKey;
@@ -132,6 +143,16 @@ export function Sidebar({ className }: SidebarProps) {
             </Link>
           )
         })}
+
+        {isAdmin && (
+          <Link
+            href="/admin"
+            className="flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-100 rounded-lg"
+          >
+            <ShieldAlert size={20} />
+            <span>Admin Panel</span>
+          </Link>
+        )}
 
         {/* Session History Section */}
         <div className="pt-4 mt-4 border-t border-slate-100">

--- a/frontend/src/components/layout/personaNavConfig.ts
+++ b/frontend/src/components/layout/personaNavConfig.ts
@@ -26,7 +26,9 @@ export const PERSONA_NAV_PRIORITIES: Record<
   ],
   startup: [
     '/dashboard/command-center',
+    '/dashboard/team',
     '/dashboard/sales',
+    '/dashboard/workflows',
     '/dashboard/content',
     '/dashboard/finance',
     '/dashboard/reports',
@@ -34,6 +36,8 @@ export const PERSONA_NAV_PRIORITIES: Record<
   ],
   sme: [
     '/dashboard/command-center',
+    '/dashboard/departments',
+    '/dashboard/team',
     '/dashboard/finance',
     '/dashboard/reports',
     '/dashboard/compliance',
@@ -42,7 +46,10 @@ export const PERSONA_NAV_PRIORITIES: Record<
   ],
   enterprise: [
     '/dashboard/command-center',
+    '/dashboard/governance',
     '/dashboard/compliance',
+    '/dashboard/departments',
+    '/dashboard/team',
     '/dashboard/reports',
     '/dashboard/approvals',
     '/dashboard/finance',

--- a/frontend/src/components/layout/sidebarNav.ts
+++ b/frontend/src/components/layout/sidebarNav.ts
@@ -4,6 +4,7 @@
 import {
   Bell,
   BookOpen,
+  Building2,
   CreditCard,
   Database,
   FileText,
@@ -13,9 +14,12 @@ import {
   MessageSquare,
   PieChart,
   Settings,
+  Shield,
   ShieldCheck,
   TrendingUp,
+  Users,
   Wallet,
+  Workflow,
   Zap
 } from 'lucide-react';
 import type { FeatureKey } from '@/config/featureGating';
@@ -68,10 +72,37 @@ export const MAIN_INTERFACE_NAV_ITEMS: NavItem[] = [
     featureKey: 'sales',
   },
   {
+    label: 'Workflows',
+    href: '/dashboard/workflows',
+    icon: Workflow,
+    featureKey: 'workflows',
+  },
+  {
     label: 'Compliance',
     href: '/dashboard/compliance',
     icon: ShieldCheck,
     featureKey: 'compliance',
+  },
+  {
+    label: 'Team Workspace',
+    href: '/dashboard/team',
+    icon: Users,
+    // Intentionally ungated per AUTH-03 (Phase 49 Plan 03): the page itself is
+    // reachable on every tier so workspace admins (invited collaborators) can
+    // manage members. The `teams` feature gate applies only to the analytics
+    // widgets rendered inside /dashboard/team.
+  },
+  {
+    label: 'Departments',
+    href: '/dashboard/departments',
+    icon: Building2,
+    featureKey: 'departments',
+  },
+  {
+    label: 'Governance',
+    href: '/dashboard/governance',
+    icon: Shield,
+    featureKey: 'governance',
   },
   {
     label: 'My Workspace',

--- a/frontend/src/config/featureGating.ts
+++ b/frontend/src/config/featureGating.ts
@@ -58,7 +58,8 @@ export type FeatureKey =
   | 'governance'
   | 'reports'
   | 'approvals'
-  | 'teams';
+  | 'teams'
+  | 'departments';
 
 // ============================================================================
 // Feature Access Record
@@ -150,6 +151,12 @@ export const FEATURE_ACCESS: Record<FeatureKey, FeatureConfig> = {
     description: 'Invite team members, assign roles, and collaborate on shared initiatives and workflows.',
     minTier: 'startup',
     route: '/dashboard/team',
+  },
+  departments: {
+    label: 'Departments',
+    description: 'Coordinate work across Engineering, Marketing, Sales, Finance, HR, Operations, Compliance, and Support.',
+    minTier: 'startup',
+    route: '/dashboard/departments',
   },
 };
 

--- a/frontend/src/hooks/useAdminAccess.ts
+++ b/frontend/src/hooks/useAdminAccess.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+// Proprietary and confidential. See LICENSE file for details.
+
+/**
+ * @fileoverview Detects whether the current user has admin role access.
+ *
+ * Calls GET /admin/check-access once on mount and caches the result in
+ * sessionStorage so the sidebar can show an "Admin Panel" entry without
+ * re-fetching on every page navigation. Admin status is role-gated server
+ * side (see app/admin/layout.tsx), not tier-gated, so it lives outside
+ * the FEATURE_ACCESS matrix.
+ */
+
+import { useEffect, useState } from 'react';
+import { fetchWithAuthRaw } from '@/services/api';
+
+const STORAGE_KEY = 'pikar:admin-access';
+
+type CachedResult = { access: boolean; ts: number };
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function readCache(): CachedResult | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const raw = window.sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as CachedResult;
+    if (Date.now() - parsed.ts > CACHE_TTL_MS) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(access: boolean): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const payload: CachedResult = { access, ts: Date.now() };
+  window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export interface AdminAccessResult {
+  isAdmin: boolean;
+  isLoading: boolean;
+}
+
+export function useAdminAccess(): AdminAccessResult {
+  const cached = readCache();
+  const [isAdmin, setIsAdmin] = useState<boolean>(cached?.access ?? false);
+  const [isLoading, setIsLoading] = useState<boolean>(cached === null);
+
+  useEffect(() => {
+    if (cached !== null) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetchWithAuthRaw('/admin/check-access');
+        if (cancelled) {
+          return;
+        }
+        if (!res.ok) {
+          setIsAdmin(false);
+          writeCache(false);
+          return;
+        }
+        const data = (await res.json()) as { access?: boolean };
+        const access = Boolean(data?.access);
+        setIsAdmin(access);
+        writeCache(access);
+      } catch {
+        if (!cancelled) {
+          setIsAdmin(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { isAdmin, isLoading };
+}

--- a/frontend/src/hooks/useEffectiveTier.ts
+++ b/frontend/src/hooks/useEffectiveTier.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+// Proprietary and confidential. See LICENSE file for details.
+
+/**
+ * @fileoverview Canonical resolution of a user's effective tier for feature
+ * gating. Replaces the divergent paths where PremiumShell read
+ * `subscription.tier` but `useFeatureGate` (and Sidebar) read `persona` —
+ * which could disagree for a startup-persona user on the free Stripe tier.
+ *
+ * Resolution order:
+ *   1. Subscription tier (canonical, billing-driven). 'free' is aliased to
+ *      'solopreneur' so unpaid users get solopreneur access.
+ *   2. Persona — used only when SubscriptionProvider is not mounted (e.g.,
+ *      surfaces outside /dashboard/* that still want to render the shell).
+ *   3. Fallback: 'solopreneur' (lowest tier).
+ */
+
+import { useSubscription } from '@/contexts/SubscriptionContext';
+import { usePersona } from '@/contexts/PersonaContext';
+import type { PersonaTier } from '@/config/featureGating';
+
+export interface EffectiveTierResult {
+  /** The tier to use for feature gating. */
+  tier: PersonaTier;
+  /** True while either provider is still bootstrapping. */
+  isLoading: boolean;
+}
+
+export function useEffectiveTier(): EffectiveTierResult {
+  // Always call both hooks — try/catch only swallows the "outside provider"
+  // throw, the hook itself is invoked on every render so the rules of hooks
+  // are preserved.
+  let subTier: PersonaTier | null = null;
+  let subReady = true;
+  try {
+    const sub = useSubscription();
+    const raw = sub.tier;
+    subTier = (raw === 'free' ? 'solopreneur' : raw) as PersonaTier;
+    subReady = sub.ready;
+  } catch {
+    // SubscriptionProvider not mounted — fall through to persona.
+  }
+
+  let personaTier: PersonaTier | null = null;
+  let personaLoading = false;
+  try {
+    const { persona, isLoading } = usePersona();
+    personaTier = persona as PersonaTier | null;
+    personaLoading = isLoading;
+  } catch {
+    // PersonaProvider not mounted either.
+  }
+
+  // Subscription is canonical when available — including when the user is on
+  // 'free' (mapped to 'solopreneur'). Persona is only the fallback path.
+  if (subTier !== null) {
+    return { tier: subTier, isLoading: !subReady };
+  }
+
+  return {
+    tier: personaTier ?? 'solopreneur',
+    isLoading: personaLoading,
+  };
+}

--- a/frontend/src/hooks/useFeatureGate.ts
+++ b/frontend/src/hooks/useFeatureGate.ts
@@ -18,7 +18,7 @@ import {
   type FeatureKey,
   type PersonaTier,
 } from '@/config/featureGating';
-import { usePersona } from '@/contexts/PersonaContext';
+import { useEffectiveTier } from '@/hooks/useEffectiveTier';
 
 // ============================================================================
 // Return type
@@ -52,7 +52,7 @@ export interface FeatureGateResult {
  * @returns Gate result with access flag, tier info, and loading state.
  */
 export function useFeatureGate(featureKey: FeatureKey): FeatureGateResult {
-  const { persona, isLoading } = usePersona();
+  const { tier, isLoading } = useEffectiveTier();
 
   const requiredTier = getRequiredTier(featureKey);
   const featureLabel = FEATURE_ACCESS[featureKey].label;
@@ -67,12 +67,11 @@ export function useFeatureGate(featureKey: FeatureKey): FeatureGateResult {
     };
   }
 
-  const currentTier = (persona as PersonaTier | null) ?? 'solopreneur';
-  const allowed = isFeatureAllowed(featureKey, currentTier);
+  const allowed = isFeatureAllowed(featureKey, tier);
 
   return {
     allowed,
-    currentTier,
+    currentTier: tier,
     requiredTier,
     isLoading: false,
     featureLabel,


### PR DESCRIPTION
## Summary

The sidebar's hand-maintained `MAIN_INTERFACE_NAV_ITEMS` had drifted from `featureGating.ts` — four gated pages (Team, Workflows, Departments, Governance) existed and had tier rules configured, but no nav entry, so **users on every tier had no way to click in**, including the startup tier these features are explicitly sold to (see billing page `FEATURE_ROWS`).

Plus a tier-resolution divergence: `PremiumShell` read `subscription.tier`, `Sidebar` and `useFeatureGate` read `persona` — a startup-persona / free-Stripe user saw locked nav icons but unlocked page content.

## Changes

**Sidebar nav (`sidebarNav.ts`, `personaNavConfig.ts`)**
- Add Team Workspace (ungated per AUTH-03 — page handles its own internal analytics gating)
- Add Workflows (solopreneur+), Departments (startup+, new feature key), Governance (enterprise)
- Persona priority reorder so startup/sme/enterprise surface their key features first

**Admin Panel link**
- New `useAdminAccess` hook calls `/admin/check-access` once per session (sessionStorage-cached, 5min TTL)
- Conditionally renders an "Admin Panel" nav entry in both `PremiumShell` and `Sidebar` shells
- Role-gated, not tier-gated

**Tier divergence fix**
- New `useEffectiveTier` hook: single source of truth. Subscription tier preferred (free → solopreneur), persona only as fallback when SubscriptionProvider isn't mounted
- All three call sites (`PremiumShell`, `Sidebar`, `useFeatureGate`) now use it

## Test plan

- [x] `tsc --noEmit` passes on this branch
- [x] 14 vitest tests pass: `PremiumShell.test.tsx` (2), `SubscriptionContext.test.tsx` (6), `empty-states.test.tsx` (5), `featureGating.test.ts` (1)
- [ ] Manual: load `/dashboard` as a startup-persona user and confirm Team / Workflows / Departments / Governance all appear in sidebar
- [ ] Manual: as a solopreneur, confirm Departments + Governance show locked with upgrade modal; Team is reachable (ungated by design)
- [ ] Manual: as an admin user, confirm "Admin Panel" entry appears under the main nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)