### PR TITLE
feat(runtime): W3 Section A — telemetry, perf budget, keyword fallback

### DIFF
--- a/app/agents/runtime/skill_injection.py
+++ b/app/agents/runtime/skill_injection.py
@@ -41,9 +41,36 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
+from opentelemetry import trace
+
 from app.skills.registry import Skill, skills_registry
 
 logger = logging.getLogger(__name__)
+
+# Module-level tracer. ``opentelemetry.trace.get_tracer`` is contract-safe
+# whether or not a TracerProvider has been configured globally — when no
+# provider is set it returns a no-op tracer, so importing this module never
+# fails and production calls never raise from a missing telemetry stack.
+# Tests patch ``_tracer`` to capture span attributes (see
+# ``test_skill_injection.py::_FakeTracer``).
+_tracer = trace.get_tracer(__name__)
+
+
+def _embeddings_warmed() -> bool:
+    """Indirection over :func:`app.skills.skill_embeddings.is_warmed`.
+
+    The runtime calls this once per turn to decide whether the semantic
+    path or the keyword fallback should run. Defined as a thin wrapper so
+    tests can monkeypatch the decision without reaching into another
+    module's globals.
+    """
+    try:
+        from app.skills.skill_embeddings import is_warmed
+
+        return bool(is_warmed())
+    except Exception:
+        return False
+
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from app.agents.runtime.types import DirectRequest, TaskContract
@@ -84,6 +111,57 @@ def _matches_any(skill_name: str, patterns: list[str]) -> bool:
     if "*" in patterns:
         return True
     return any(fnmatch.fnmatchcase(skill_name, p) for p in patterns)
+
+
+# ---------------------------------------------------------------------------
+# Keyword fallback (W3 A3-lite)
+# ---------------------------------------------------------------------------
+
+
+def _keyword_match_skills(
+    query: str,
+    skills: list[Skill],
+    *,
+    allowed: list[str],
+    top_k: int,
+) -> list[SkillMatch]:
+    """Substring fallback used when the embedding cache is cold.
+
+    Splits ``query`` into >2-char tokens, scores each candidate skill by
+    the fraction of tokens that appear (lowercased substring match) in
+    the skill's name + description + knowledge_summary, and returns the
+    top-K matches whose score clears 0.65 (the default similarity floor).
+
+    Score formula: ``0.65 + 0.30 * (hits / total_tokens)`` — keeps the
+    fallback's scores in the ``[0.65, 0.95]`` band so they don't claim
+    higher confidence than semantic matches (which can reach 1.0).
+
+    Agent scope filtering (``skill.agent_ids``) is the caller's job —
+    pass ``skills`` already scoped via ``skills_registry.get_by_agent_id``.
+    """
+    query_tokens = {t for t in query.lower().split() if len(t) > 2}
+    if not query_tokens:
+        return []
+
+    matches: list[SkillMatch] = []
+    for skill in skills:
+        if not _matches_any(skill.name, allowed):
+            continue
+        haystack = " ".join(
+            (
+                skill.name,
+                getattr(skill, "description", "") or "",
+                getattr(skill, "knowledge_summary", "") or "",
+            )
+        ).lower()
+        hits = sum(1 for token in query_tokens if token in haystack)
+        if hits == 0:
+            continue
+        score = 0.65 + 0.30 * (hits / len(query_tokens))
+        matches.append(SkillMatch(score=score, skill=skill))
+
+    matches.sort(key=lambda m: m.score, reverse=True)
+    return matches[:top_k]
 
 
 # ---------------------------------------------------------------------------
@@ -166,75 +244,120 @@ async def match_and_inject(
         The rendered markdown block, or an empty string when no skills
         clear the threshold (or when direct-mode skipping kicks in).
     """
-    # --- direct-mode exclusion -----------------------------------------
-    injection_cfg = getattr(getattr(agent, "ops", None), "skills", None)
-    injection_cfg = getattr(injection_cfg, "injection", None)
-    eff_skip_direct = (
-        skip_direct_mode
-        if skip_direct_mode is not None
-        else bool(getattr(injection_cfg, "skip_direct_mode", False))
-    )
-    if mode == "direct" and eff_skip_direct:
-        return ""
-
-    # --- effective config (caller overrides win) ------------------------
-    eff_top_k = (
-        top_k if top_k is not None else int(getattr(injection_cfg, "top_k", 5) or 5)
-    )
-    eff_floor = (
-        similarity_floor
-        if similarity_floor is not None
-        else float(getattr(injection_cfg, "similarity_floor", 0.65) or 0.65)
-    )
-
-    # --- query extraction ----------------------------------------------
-    query = _extract_query(request)
-    if not query:
-        return ""
-
-    # --- candidate retrieval (over-fetch so allowed_ids post-filter
-    #     does not under-count) ---------------------------------------
-    try:
-        candidates = skills_registry.semantic_search(
-            query=query,
-            agent_id=getattr(agent, "agent_id", None),
-            limit=max(eff_top_k * 3, eff_top_k),
-            threshold=eff_floor,
+    with _tracer.start_as_current_span("pikar.skill_injection.match") as span:
+        # Baseline attributes — set first so they're always present on the
+        # span even if an early return fires.
+        agent_id_value = getattr(getattr(agent, "agent_id", None), "value", None)
+        span.set_attribute(
+            "pikar.agent_id",
+            str(agent_id_value) if agent_id_value is not None else "",
         )
-    except Exception as exc:
-        logger.debug("[skill_injection] semantic_search failed: %s", exc)
-        return ""
+        span.set_attribute("pikar.mode", mode or "unknown")
 
-    if not candidates:
-        return ""
+        # --- direct-mode exclusion -----------------------------------------
+        injection_cfg = getattr(getattr(agent, "ops", None), "skills", None)
+        injection_cfg = getattr(injection_cfg, "injection", None)
+        eff_skip_direct = (
+            skip_direct_mode
+            if skip_direct_mode is not None
+            else bool(getattr(injection_cfg, "skip_direct_mode", False))
+        )
+        if mode == "direct" and eff_skip_direct:
+            span.set_attribute("pikar.skipped", "direct_mode")
+            return ""
 
-    allowed = list(
-        getattr(getattr(agent, "ops", None), "skills", None).allowed_ids
-        if getattr(getattr(agent, "ops", None), "skills", None) is not None
-        and getattr(getattr(agent.ops, "skills", None), "allowed_ids", None) is not None
-        else ["*"]
-    )
+        # --- effective config (caller overrides win) ------------------------
+        eff_top_k = (
+            top_k if top_k is not None else int(getattr(injection_cfg, "top_k", 5) or 5)
+        )
+        eff_floor = (
+            similarity_floor
+            if similarity_floor is not None
+            else float(getattr(injection_cfg, "similarity_floor", 0.65) or 0.65)
+        )
+        span.set_attribute("pikar.top_k", eff_top_k)
+        span.set_attribute("pikar.similarity_floor", eff_floor)
 
-    agent_id = getattr(agent, "agent_id", None)
-    matches: list[SkillMatch] = []
-    for candidate in candidates:
-        score = float(candidate.get("score", 0.0))
-        skill = candidate.get("skill")
-        if skill is None:
-            continue
-        if score < eff_floor:
-            continue
-        # empty agent_ids list means available to all agents
-        skill_agents = getattr(skill, "agent_ids", None) or []
-        if skill_agents and agent_id not in skill_agents:
-            continue
-        if not _matches_any(skill.name, allowed):
-            continue
-        matches.append(SkillMatch(score=score, skill=skill))
-        if len(matches) >= eff_top_k:
-            break
+        # --- query extraction ----------------------------------------------
+        query = _extract_query(request)
+        span.set_attribute("pikar.query_len", len(query))
+        if not query:
+            span.set_attribute("pikar.skipped", "empty_query")
+            return ""
 
-    return _render_section(matches)
+        allowed = list(
+            getattr(getattr(agent, "ops", None), "skills", None).allowed_ids
+            if getattr(getattr(agent, "ops", None), "skills", None) is not None
+            and getattr(getattr(agent.ops, "skills", None), "allowed_ids", None)
+            is not None
+            else ["*"]
+        )
+        agent_id = getattr(agent, "agent_id", None)
+
+        # --- matcher routing ------------------------------------------------
+        # In production the embedding cache is warmed at startup and the
+        # semantic path runs. In dev/test environments without Vertex
+        # credentials ``is_warmed()`` stays False, so we fall back to a
+        # substring matcher to keep skill injection useful locally.
+        if not _embeddings_warmed():
+            span.set_attribute("pikar.matcher", "keyword_fallback")
+            try:
+                scoped = skills_registry.get_by_agent_id(agent_id) if agent_id else []
+            except Exception as exc:
+                span.set_attribute("pikar.error", str(exc)[:200])
+                logger.debug("[skill_injection] get_by_agent_id failed: %s", exc)
+                return ""
+            span.set_attribute("pikar.candidate_count", len(scoped))
+            keyword_matches = _keyword_match_skills(
+                query=query,
+                skills=scoped,
+                allowed=allowed,
+                top_k=eff_top_k,
+            )
+            span.set_attribute("pikar.matched_count", len(keyword_matches))
+            return _render_section(keyword_matches)
+
+        span.set_attribute("pikar.matcher", "semantic")
+
+        # --- candidate retrieval (over-fetch so allowed_ids post-filter
+        #     does not under-count) ---------------------------------------
+        try:
+            candidates = skills_registry.semantic_search(
+                query=query,
+                agent_id=agent_id,
+                limit=max(eff_top_k * 3, eff_top_k),
+                threshold=eff_floor,
+            )
+        except Exception as exc:
+            span.set_attribute("pikar.error", str(exc)[:200])
+            logger.debug("[skill_injection] semantic_search failed: %s", exc)
+            return ""
+
+        span.set_attribute("pikar.candidate_count", len(candidates))
+        if not candidates:
+            span.set_attribute("pikar.matched_count", 0)
+            return ""
+
+        matches: list[SkillMatch] = []
+        for candidate in candidates:
+            score = float(candidate.get("score", 0.0))
+            skill = candidate.get("skill")
+            if skill is None:
+                continue
+            if score < eff_floor:
+                continue
+            # empty agent_ids list means available to all agents
+            skill_agents = getattr(skill, "agent_ids", None) or []
+            if skill_agents and agent_id not in skill_agents:
+                continue
+            if not _matches_any(skill.name, allowed):
+                continue
+            matches.append(SkillMatch(score=score, skill=skill))
+            if len(matches) >= eff_top_k:
+                break
+
+        span.set_attribute("pikar.matched_count", len(matches))
+        return _render_section(matches)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-05-11-agent-operating-model-w3.md
+++ b/docs/superpowers/plans/2026-05-11-agent-operating-model-w3.md
@@ -32,6 +32,25 @@ A W3 PR is mergeable when:
 
 ---
 
+## 1a. Section A status — post-survey reconciliation (2026-05-11)
+
+After this plan landed on `main` (PR #26), a survey of the existing codebase showed that **most of Section A was already shipped** during W1/W2 — the plan was written from the spec § 17 description rather than against the actual code. The reconciliation:
+
+| Task in plan | Reality | Disposition |
+|---|---|---|
+| **A1** Define `SkillMatcher` protocol | `skills_registry.semantic_search` is the live matcher interface (`app/skills/registry.py:224`) | Already shipped |
+| **A2** `VertexEmbeddingMatcher` | `app/rag/embedding_service.py` + `app/skills/skill_embeddings.py` warm-cache | Already shipped |
+| **A3** `KeywordFallbackMatcher` | No keyword fallback existed — dev environments without Vertex got empty injection | **A3-lite shipped** (substring tokens over name + description + summary; scores capped in `[0.65, 0.95]`; fires when `is_warmed()` returns False) |
+| **A4** Factory + `SKILL_MATCHER` env var | `startup_warmup_enabled()` auto-detects via `SKILL_EMBEDDING_WARMUP_ENABLED` + `K_SERVICE` | Already shipped |
+| **A5** Wire `match_and_inject` to matcher | `skill_injection.py:140` already calls `semantic_search` | Already shipped |
+| **A6** OTel span `pikar.skill_injection.match` | Was missing | **Shipped** in this PR — span emitted on every call with attributes `agent_id`, `mode`, `top_k`, `similarity_floor`, `query_len`, `matcher` (semantic\|keyword_fallback), `candidate_count`, `matched_count`, optional `skipped` and `error` |
+| **A7** Perf regression test p95 < 80ms | Was missing | **Shipped** — 100-iteration loop with mocked semantic search, asserts p95 < 80ms |
+| **A8** Backfill migration | `warmup_skill_embeddings()` runs at startup | Already shipped |
+
+Net delta: 3 changes (A6, A7, A3-lite) instead of 8 tasks. The lesson for Sections B–D: **survey before re-deriving the plan**. Section B (executive migration + shadow router) and Sections C/D (marketing + data migration) should each get a brief code survey before execution to avoid duplicate work.
+
+---
+
 ## 2. Pre-requisites
 
 - W1/W2 merged to `main` (this is being landed via PR #25).

--- a/tests/unit/agents/runtime/test_skill_injection.py
+++ b/tests/unit/agents/runtime/test_skill_injection.py
@@ -19,6 +19,8 @@ import asyncio
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 # Stub the google.adk + google.genai surface so importing modules that
 # reference ADK types does not require the real SDK during unit tests.
 sys.modules.setdefault("google.adk", MagicMock())
@@ -30,6 +32,26 @@ sys.modules.setdefault("google.genai", MagicMock())
 sys.modules.setdefault("google.genai.types", MagicMock())
 
 from app.skills.registry import AgentID, Skill  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Default-warmed-embeddings fixture (W3 A3-lite + A6)
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _force_embeddings_warmed_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to the semantic-search code path.
+
+    The W3 A3-lite keyword fallback fires when
+    ``skill_injection._embeddings_warmed()`` returns ``False``. In a real
+    process that's the case for unit tests (no warming runs) — but the
+    existing tests in this file were written assuming the semantic path,
+    so we pin it to ``True`` by default. The handful of A3-lite tests
+    that want the keyword path override this with their own
+    ``patch.object(skill_injection, "_embeddings_warmed", lambda: False)``.
+    """
+    from app.agents.runtime import skill_injection
+
+    monkeypatch.setattr(skill_injection, "_embeddings_warmed", lambda: True)
 
 
 # ---------------------------------------------------------------------------
@@ -173,9 +195,7 @@ def test_matches_any_exact_match_in_list():
         "compliance:legal-risk-assessment",
         ["compliance:legal-risk-assessment"],
     )
-    assert not _matches_any(
-        "compliance:other", ["compliance:legal-risk-assessment"]
-    )
+    assert not _matches_any("compliance:other", ["compliance:legal-risk-assessment"])
 
 
 def test_matches_any_empty_patterns_denies_everything():
@@ -218,9 +238,7 @@ def test_match_and_inject_filters_by_floor_and_allowed_and_agent_ids():
 
     with patch.object(skill_injection, "skills_registry", fake_registry):
         out = asyncio.run(
-            skill_injection.match_and_inject(
-                _request("forecast Q3 revenue"), agent
-            )
+            skill_injection.match_and_inject(_request("forecast Q3 revenue"), agent)
         )
 
     assert "finance:dcf" in out
@@ -237,9 +255,7 @@ def test_match_and_inject_empty_when_no_matches():
 
     agent = _agent_mock(allowed=["*"])
     with patch.object(skill_injection, "skills_registry", fake_registry):
-        out = asyncio.run(
-            skill_injection.match_and_inject(_request("hello"), agent)
-        )
+        out = asyncio.run(skill_injection.match_and_inject(_request("hello"), agent))
     assert out == ""
 
 
@@ -275,9 +291,7 @@ def test_match_and_inject_wildcard_allowed_passes_everything():
 
     agent = _agent_mock(allowed=["*"])
     with patch.object(skill_injection, "skills_registry", fake_registry):
-        out = asyncio.run(
-            skill_injection.match_and_inject(_request("hi"), agent)
-        )
+        out = asyncio.run(skill_injection.match_and_inject(_request("hi"), agent))
     assert "anything:goes" in out
 
 
@@ -308,9 +322,7 @@ def test_match_and_inject_handles_registry_exception_gracefully():
 
     agent = _agent_mock(allowed=["*"])
     with patch.object(skill_injection, "skills_registry", fake_registry):
-        out = asyncio.run(
-            skill_injection.match_and_inject(_request("question"), agent)
-        )
+        out = asyncio.run(skill_injection.match_and_inject(_request("question"), agent))
     # Failure must not break the turn - return empty so caller can no-op.
     assert out == ""
 
@@ -325,9 +337,7 @@ def test_match_and_inject_skill_with_empty_agent_ids_available_to_all():
 
     agent = _agent_mock(allowed=["*"], agent_id=AgentID.HR)
     with patch.object(skill_injection, "skills_registry", fake_registry):
-        out = asyncio.run(
-            skill_injection.match_and_inject(_request("x"), agent)
-        )
+        out = asyncio.run(skill_injection.match_and_inject(_request("x"), agent))
     assert "global_skill" in out
 
 
@@ -466,9 +476,7 @@ def test_match_and_inject_skips_when_ops_flag_set_and_mode_direct():
     agent = _agent_mock(allowed=["*"], skip_direct_mode=True)
     with patch.object(skill_injection, "skills_registry", fake_registry):
         out = asyncio.run(
-            skill_injection.match_and_inject(
-                _request("question"), agent, mode="direct"
-            )
+            skill_injection.match_and_inject(_request("question"), agent, mode="direct")
         )
 
     assert out == ""
@@ -504,14 +512,10 @@ def test_match_and_inject_default_behavior_inject_for_both_modes():
     agent = _agent_mock(allowed=["*"], skip_direct_mode=False)
     with patch.object(skill_injection, "skills_registry", fake_registry):
         out_direct = asyncio.run(
-            skill_injection.match_and_inject(
-                _request("q"), agent, mode="direct"
-            )
+            skill_injection.match_and_inject(_request("q"), agent, mode="direct")
         )
         out_initiative = asyncio.run(
-            skill_injection.match_and_inject(
-                _request("q"), agent, mode="initiative"
-            )
+            skill_injection.match_and_inject(_request("q"), agent, mode="initiative")
         )
 
     assert "finance:x" in out_direct
@@ -538,3 +542,383 @@ def test_match_and_inject_kwarg_overrides_ops_flag_when_explicitly_false():
         )
 
     assert "finance:x" in out
+
+
+# ===========================================================================
+# W3 Section A — Task A6: OTel telemetry on match_and_inject
+# ===========================================================================
+
+
+class _FakeSpan:
+    """A minimal stand-in for an OTel Span that records set_attribute calls.
+
+    We don't use the real opentelemetry.sdk here because
+    ``tests/unit/conftest.py`` stubs the top-level ``opentelemetry`` module
+    with a MagicMock — ``from opentelemetry.sdk.trace import ...`` would
+    fail under pytest. The fake captures everything the test needs to
+    assert against: span name and the attribute map.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def __enter__(self) -> _FakeSpan:
+        return self
+
+    def __exit__(self, *exc_info: object) -> bool | None:
+        return None
+
+
+class _FakeTracer:
+    """Captures every span created via ``start_as_current_span``."""
+
+    def __init__(self) -> None:
+        self.spans: list[_FakeSpan] = []
+
+    def start_as_current_span(self, name: str) -> _FakeSpan:
+        span = _FakeSpan(name)
+        self.spans.append(span)
+        return span
+
+
+def test_match_and_inject_emits_otel_span_with_attributes():
+    """W3-A6: ``match_and_inject`` emits an OTel span
+    ``pikar.skill_injection.match`` with attributes useful for tracing the
+    matcher hot path (agent_id, mode, query_len, top_k, similarity_floor,
+    candidate_count, matched_count). Latency is implicit in the span's
+    start/end timestamps.
+    """
+    from app.agents.runtime import skill_injection
+
+    fake_tracer = _FakeTracer()
+    fake_registry = MagicMock()
+    fake_registry.semantic_search = MagicMock(
+        return_value=[
+            {
+                "score": 0.82,
+                "skill": _skill(
+                    "finance:budget_modeling",
+                    description="DCF + sensitivity",
+                ),
+            },
+        ]
+    )
+
+    agent = _agent_mock(allowed=["finance:*"], top_k=5, floor=0.65)
+
+    with (
+        patch.object(skill_injection, "skills_registry", fake_registry),
+        patch.object(skill_injection, "_tracer", fake_tracer),
+    ):
+        asyncio.run(
+            skill_injection.match_and_inject(
+                _request("draft Q3 budget plan"),
+                agent,
+                mode="initiative",
+            )
+        )
+
+    assert len(fake_tracer.spans) == 1, (
+        f"expected exactly one span, got: {[s.name for s in fake_tracer.spans]}"
+    )
+    span = fake_tracer.spans[0]
+    assert span.name == "pikar.skill_injection.match"
+    # Required attributes — the dashboard / Cloud Trace filters depend on them.
+    assert span.attributes.get("pikar.mode") == "initiative"
+    assert span.attributes.get("pikar.top_k") == 5
+    assert span.attributes.get("pikar.similarity_floor") == 0.65
+    assert span.attributes.get("pikar.query_len") == len("draft Q3 budget plan")
+    assert span.attributes.get("pikar.candidate_count") == 1
+    assert span.attributes.get("pikar.matched_count") == 1
+    # agent_id is the AgentID enum's `.value`. The mock fixture defaults to
+    # AgentID.FIN whose value is "FIN".
+    assert span.attributes.get("pikar.agent_id") == "FIN"
+
+
+def test_match_and_inject_span_records_zero_matches_when_below_floor():
+    """W3-A6: span attributes must report candidate_count and matched_count
+    even when no candidates clear the similarity floor. This is the
+    high-signal case for the observability dashboard — a non-zero candidate
+    count with zero matches means the floor is too aggressive for the
+    agent's query mix."""
+    from app.agents.runtime import skill_injection
+
+    fake_tracer = _FakeTracer()
+    fake_registry = MagicMock()
+    # Score below the agent's similarity_floor of 0.65 — candidates exist
+    # but none should clear the gate.
+    fake_registry.semantic_search = MagicMock(
+        return_value=[
+            {"score": 0.50, "skill": _skill("finance:noise")},
+            {"score": 0.30, "skill": _skill("finance:more_noise")},
+        ]
+    )
+
+    agent = _agent_mock(allowed=["finance:*"], top_k=5, floor=0.65)
+
+    with (
+        patch.object(skill_injection, "skills_registry", fake_registry),
+        patch.object(skill_injection, "_tracer", fake_tracer),
+    ):
+        asyncio.run(
+            skill_injection.match_and_inject(
+                _request("something tangential"),
+                agent,
+                mode="initiative",
+            )
+        )
+
+    span = fake_tracer.spans[0]
+    assert span.name == "pikar.skill_injection.match"
+    # Either semantic_search returned 0 candidates (pre-filter on threshold)
+    # or returned them and match_and_inject's own floor check rejected them.
+    # Either way the matched_count is zero.
+    assert span.attributes.get("pikar.matched_count") == 0
+
+
+def test_match_and_inject_span_emitted_on_direct_mode_skip():
+    """W3-A6: even when direct-mode skipping suppresses injection, the
+    span must still emit so the dashboard can distinguish 'no candidates'
+    from 'intentionally skipped'."""
+    from app.agents.runtime import skill_injection
+
+    fake_tracer = _FakeTracer()
+    agent = _agent_mock(skip_direct_mode=True)
+
+    with patch.object(skill_injection, "_tracer", fake_tracer):
+        result = asyncio.run(
+            skill_injection.match_and_inject(
+                _request("hi"),
+                agent,
+                mode="direct",
+                skip_direct_mode=True,
+            )
+        )
+
+    assert result == ""
+    assert len(fake_tracer.spans) == 1
+    span = fake_tracer.spans[0]
+    assert span.name == "pikar.skill_injection.match"
+    # The dashboard needs a clear signal for skipped turns.
+    assert span.attributes.get("pikar.skipped") == "direct_mode"
+
+
+# ===========================================================================
+# W3 Section A — Task A7: performance regression test
+# ===========================================================================
+
+
+def test_match_and_inject_p95_latency_under_budget():
+    """W3-A7: Performance regression test. With the semantic-search step
+    mocked to return instantly, ``match_and_inject``'s own overhead (config
+    resolution, filter loop, attribute setting, markdown render) must keep
+    p95 latency well under the 80ms hot-path budget from the W3 plan.
+
+    The test exists to catch regressions like:
+    * a synchronous Supabase/Vertex call sneaking into the hot path,
+    * an O(n²) loop introduced when the candidate pool grows,
+    * lock contention or runaway logging in the matcher.
+
+    Mocked execution should be sub-millisecond per call. The 80ms budget is
+    generous on purpose — the test fires loud only when something is
+    *seriously* wrong, not on incidental CI variance.
+    """
+    import time
+
+    from app.agents.runtime import skill_injection
+
+    fake_registry = MagicMock()
+    fake_registry.semantic_search = MagicMock(
+        return_value=[
+            {"score": 0.85, "skill": _skill(f"finance:skill_{i}")} for i in range(10)
+        ]
+    )
+    agent = _agent_mock(allowed=["finance:*"], top_k=5)
+
+    async def _iterations(n: int) -> list[float]:
+        out: list[float] = []
+        for _ in range(n):
+            t0 = time.perf_counter_ns()
+            await skill_injection.match_and_inject(
+                _request("a representative goal text"),
+                agent,
+                mode="initiative",
+            )
+            out.append((time.perf_counter_ns() - t0) / 1_000_000.0)
+        return out
+
+    with patch.object(skill_injection, "skills_registry", fake_registry):
+        durations = asyncio.run(_iterations(100))
+
+    durations.sort()
+    p50 = durations[len(durations) // 2]
+    p95 = durations[int(len(durations) * 0.95)]
+    p99 = durations[min(int(len(durations) * 0.99), len(durations) - 1)]
+
+    # The budget catches a 10-100x regression. On mocked I/O p95 should be
+    # under a couple of milliseconds in practice.
+    assert p95 < 80.0, (
+        f"match_and_inject p95 latency {p95:.2f}ms exceeds 80ms budget "
+        f"(p50={p50:.2f}ms, p99={p99:.2f}ms). "
+        f"Slowest 5: {[f'{d:.2f}' for d in durations[-5:]]}"
+    )
+
+
+# ===========================================================================
+# W3 Section A — Task A3-lite: keyword fallback when embeddings cold
+# ===========================================================================
+
+
+def test_keyword_fallback_fires_when_embeddings_cold():
+    """W3-A3-lite: when ``skill_embeddings.is_warmed()`` returns False
+    (dev environment without Vertex creds, or a fresh process where the
+    embedding cache hasn't been warmed yet), ``match_and_inject`` falls
+    back to a substring match over skill name/description/summary so
+    relevant skills still surface — instead of returning the empty string
+    and losing all skill-injection value.
+
+    Production keeps the semantic path because ``is_warmed()`` returns True
+    once ``warmup_skill_embeddings()`` has run at startup.
+    """
+    from app.agents.runtime import skill_injection
+
+    fake_tracer = _FakeTracer()
+    fake_registry = MagicMock()
+    fake_registry.get_by_agent_id = MagicMock(
+        return_value=[
+            _skill("finance:budget_modeling", description="DCF, NPV, IRR modeling"),
+            _skill("finance:variance_analysis", description="Budget vs actuals"),
+            _skill("hr:hiring_funnel", description="Recruiting pipeline tactics"),
+        ]
+    )
+    # semantic_search would return [] when embeddings are cold; mock that.
+    fake_registry.semantic_search = MagicMock(return_value=[])
+
+    agent = _agent_mock(allowed=["finance:*", "hr:*"], top_k=5, floor=0.65)
+
+    # Force the embeddings-cold code path.
+    with (
+        patch.object(skill_injection, "skills_registry", fake_registry),
+        patch.object(skill_injection, "_tracer", fake_tracer),
+        patch.object(skill_injection, "_embeddings_warmed", lambda: False),
+    ):
+        out = asyncio.run(
+            skill_injection.match_and_inject(
+                _request("draft a DCF budget"),
+                agent,
+                mode="initiative",
+            )
+        )
+
+    assert "finance:budget_modeling" in out, (
+        "DCF query should surface the budget_modeling skill via keyword fallback"
+    )
+    # The unrelated HR skill must NOT appear — only substring hits.
+    assert "hr:hiring_funnel" not in out
+
+    # Span attribute distinguishes which matcher fired so dashboards can
+    # filter ``matcher = "keyword_fallback"`` to spot dev environments
+    # leaking into production traces.
+    span = fake_tracer.spans[0]
+    assert span.attributes.get("pikar.matcher") == "keyword_fallback"
+    assert span.attributes.get("pikar.matched_count", 0) >= 1
+
+
+def test_keyword_fallback_does_not_fire_when_embeddings_warm():
+    """W3-A3-lite: when ``is_warmed()`` returns True (production), the
+    semantic-search path is used and the keyword fallback never runs.
+    The span attribute must say ``matcher = "semantic"``."""
+    from app.agents.runtime import skill_injection
+
+    fake_tracer = _FakeTracer()
+    fake_registry = MagicMock()
+    fake_registry.semantic_search = MagicMock(
+        return_value=[
+            {"score": 0.88, "skill": _skill("finance:budget_modeling")},
+        ]
+    )
+    # get_by_agent_id should NOT be consulted on the semantic path.
+    fake_registry.get_by_agent_id = MagicMock(
+        side_effect=AssertionError(
+            "get_by_agent_id must not be called when embeddings are warm"
+        )
+    )
+
+    agent = _agent_mock(allowed=["finance:*"], top_k=5, floor=0.65)
+
+    with (
+        patch.object(skill_injection, "skills_registry", fake_registry),
+        patch.object(skill_injection, "_tracer", fake_tracer),
+        patch.object(skill_injection, "_embeddings_warmed", lambda: True),
+    ):
+        asyncio.run(
+            skill_injection.match_and_inject(
+                _request("budget"),
+                agent,
+                mode="initiative",
+            )
+        )
+
+    span = fake_tracer.spans[0]
+    assert span.attributes.get("pikar.matcher") == "semantic"
+
+
+def test_keyword_fallback_respects_agent_scope_and_allowed_ids():
+    """W3-A3-lite: the keyword path must enforce the same gates as the
+    semantic path — agent scope (skill.agent_ids) and allowed_ids glob.
+    A skill that substring-matches but is scoped to a different agent OR
+    excluded by allowed_ids must NOT appear."""
+    from app.agents.runtime import skill_injection
+    from app.skills.registry import AgentID
+
+    fake_tracer = _FakeTracer()
+    fake_registry = MagicMock()
+    fake_registry.get_by_agent_id = MagicMock(
+        return_value=[
+            # Matches query AND is in scope for AgentID.FIN (default mock id):
+            _skill(
+                "finance:budget_modeling",
+                description="budget DCF NPV",
+                agent_ids=[AgentID.FIN],
+            ),
+            # Matches query BUT scoped to a different agent (HR):
+            _skill(
+                "hr:budget_negotiation",
+                description="budget conversation tactics",
+                agent_ids=[AgentID.HR] if hasattr(AgentID, "HR") else [],
+            ),
+            # Matches query BUT excluded by allowed_ids (no glob hit on data:*):
+            _skill(
+                "data:budget_dashboard",
+                description="budget visualization",
+                agent_ids=[],  # available to all agents
+            ),
+        ]
+    )
+    fake_registry.semantic_search = MagicMock(return_value=[])
+
+    agent = _agent_mock(
+        allowed=["finance:*"],  # only finance:* permitted
+        top_k=5,
+        floor=0.65,
+    )
+
+    with (
+        patch.object(skill_injection, "skills_registry", fake_registry),
+        patch.object(skill_injection, "_tracer", fake_tracer),
+        patch.object(skill_injection, "_embeddings_warmed", lambda: False),
+    ):
+        out = asyncio.run(
+            skill_injection.match_and_inject(
+                _request("budget"),
+                agent,
+                mode="initiative",
+            )
+        )
+
+    assert "finance:budget_modeling" in out
+    assert "data:budget_dashboard" not in out, "allowed_ids glob must filter"


### PR DESCRIPTION
## Summary

Ships **W3 Section A** of the agent operating model, scoped down after surveying the existing codebase. Most of the original Section A (A1, A2, A4, A5, A8 — semantic matcher protocol, Vertex adapter, factory, wiring, startup warmup) was **already shipped in W1/W2** — the plan was written from spec § 17 description rather than against the actual code. This PR fills the three real gaps and amends the plan to keep future readers honest.

See \`docs/superpowers/plans/2026-05-11-agent-operating-model-w3.md\` § 1a for the full reconciliation table.

## What's in this PR

### A6 — OpenTelemetry span on the matcher hot path  (commit \`38b0d323\`)

\`match_and_inject\` now emits a \`pikar.skill_injection.match\` span on every call with attributes:

| Attribute | Type | Purpose |
|---|---|---|
| \`pikar.agent_id\` | str | Filter by agent in traces |
| \`pikar.mode\` | str | direct \| initiative \| unknown |
| \`pikar.top_k\` | int | Effective top-K after override/config resolution |
| \`pikar.similarity_floor\` | float | Effective floor |
| \`pikar.query_len\` | int | Chars in the user request |
| \`pikar.matcher\` | str | \`semantic\` \| \`keyword_fallback\` |
| \`pikar.candidate_count\` | int | Pre-filter candidate pool size |
| \`pikar.matched_count\` | int | Post-filter result size |
| \`pikar.skipped\` | str (optional) | \`direct_mode\` \| \`empty_query\` when early-returning |
| \`pikar.error\` | str (optional) | Truncated exception message when semantic_search throws |

Uses module-level \`trace.get_tracer(__name__)\` — falls back to OTel's no-op tracer when no provider is configured, so importing the module never fails even in dev envs without telemetry setup.

### A7 — Performance regression test  (commit \`38b0d323\`)

100-iteration loop with mocked \`semantic_search\` asserts p95 latency < 80ms (the W3 plan's stated hot-path budget). Mocked execution is sub-millisecond in practice; the budget catches gross regressions like synchronous I/O sneaking into the hot path or O(n²) loops on large candidate pools.

### A3-lite — Keyword fallback when embeddings cold  (commit \`38b0d323\`)

When \`app.skills.skill_embeddings.is_warmed()\` returns False (dev envs without Vertex credentials, fresh process before \`warmup_skill_embeddings()\` runs), \`match_and_inject\` falls back to a substring tokenizer over \`skill.name + description + knowledge_summary\`. Score formula: \`0.65 + 0.30 × (hits / total_tokens)\` — keeps fallback scores in \`[0.65, 0.95]\` so they never claim higher confidence than semantic matches. Same agent-scope and \`allowed_ids\` gates as the semantic path.

### Plan reconciliation note  (commit \`3b241e04\`)

Adds Section 1a to the W3 plan documenting which Section A tasks were already shipped vs which needed new code. Surfaces a lesson for B/C/D: survey the codebase before re-deriving plan content from the spec.

## Test plan

- [x] \`uv run pytest tests/unit/agents tests/integration/agents\` — **432 passing** (+7 over W1/W2 baseline)
  - 3 A6 telemetry tests (span emitted, attributes correct, skipped-mode attribute)
  - 1 A7 perf regression test
  - 3 A3-lite tests (fires when cold, doesn't fire when warm, respects agent scope + allowed_ids)
- [x] \`uv run ruff check\` — clean
- [x] \`uv run ruff format --check\` — clean
- [ ] CI to run the full test suite + Trust Gates

## Risks & mitigations

| Risk | Mitigation |
|---|---|
| OTel no-op tracer when telemetry isn't configured | \`get_tracer\` is contract-safe — always returns a tracer (real or no-op). No-op tracer's spans are zero-cost. |
| Test pollution from autouse fixture pinning \`_embeddings_warmed=True\` | Keyword-fallback tests opt out by overriding with \`patch.object(..., lambda: False)\`. Test isolation preserved via pytest's monkeypatch teardown. |
| Keyword fallback over-matches in production if Vertex flaps | Won't fire — \`is_warmed()\` only flips to False if the cache empties, which doesn't happen mid-process. Worst case in a flap: agent gets keyword-matched skills (slightly worse signal) instead of zero skills. |

## Follow-up

This is the only piece of Section A. Section B (executive migration + 10% shadow traffic) is next per the W3 plan. The reconciliation note's lesson applies: I'll survey before re-deriving Section B's task list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)