### PR TITLE
feat(runtime): W3 Section B — shadow router for legacy-vs-manifest executive

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -52,10 +52,13 @@ from app.agents.shared_instructions import (
 # loaded lazily inside __getattr__ below. Importing specialized_agents at
 # module top instantiates 10 sub-agents (~3.4s) before the FastAPI worker
 # can accept TCP, which causes Cloud Run startup-probe TCP timeouts.
-
 # Import Skill tools for accessing and creating skills (agent-aware)
 from app.agents.tools.agent_skills import EXEC_SKILL_TOOLS
 from app.agents.tools.app_builder import APP_BUILDER_TOOLS
+
+# Import in-chat approval tools (request + async wait) for the inline
+# Approve/Reject card pattern (ARTIFACT-03 / ARTIFACT-04)
+from app.agents.tools.approval_tool import APPROVAL_TOOLS
 from app.agents.tools.base import sanitize_tools as _sanitize
 from app.agents.tools.brain_dump import get_braindump_document
 
@@ -79,10 +82,6 @@ from app.agents.tools.deep_research import DEEP_RESEARCH_TOOLS
 
 # Import document generation tools (PDF reports, PowerPoint pitch decks)
 from app.agents.tools.document_gen import DOCUMENT_GEN_TOOLS
-
-# Import in-chat approval tools (request + async wait) for the inline
-# Approve/Reject card pattern (ARTIFACT-03 / ARTIFACT-04)
-from app.agents.tools.approval_tool import APPROVAL_TOOLS
 
 # Import long-running job handoff tool (LONGTASK-01)
 from app.agents.tools.long_task import LONG_TASK_TOOLS
@@ -402,9 +401,7 @@ def _build_executive_agent(model, sub_agents=None, persona: str | None = None):
             logger.exception(
                 "Manifest-built Executive failed; falling back to legacy factory"
             )
-    return _build_executive_agent_legacy(
-        model, sub_agents=sub_agents, persona=persona
-    )
+    return _build_executive_agent_legacy(model, sub_agents=sub_agents, persona=persona)
 
 
 def _build_fallback_sub_agents(persona: str | None = None):
@@ -493,12 +490,15 @@ APP_NAME = "agents"  # Must match directory where agent is loaded from (app/agen
 
 _executive_agent: "Agent | None" = None
 _executive_agent_fallback: "Agent | None" = None
+_executive_agent_shadow_candidate: "Agent | None" = None
 _app = None  # google.adk.apps.App
 _app_fallback = None  # google.adk.apps.App
+_app_shadow_candidate = None  # google.adk.apps.App
 
 
 def __getattr__(name: str):
     global _executive_agent, _executive_agent_fallback, _app, _app_fallback
+    global _executive_agent_shadow_candidate, _app_shadow_candidate
 
     if name in ("executive_agent", "root_agent"):
         if _executive_agent is None:
@@ -515,6 +515,24 @@ def __getattr__(name: str):
                 get_fallback_model(), sub_agents=_build_fallback_sub_agents()
             )
         return _executive_agent_fallback
+
+    if name == "executive_agent_shadow_candidate":
+        # W3 Section B (B-Alpha-Plus): build the OPPOSITE variant of what
+        # production uses so the shadow router can compare the two.
+        if _executive_agent_shadow_candidate is None:
+            from app.agents.specialized_agents import SPECIALIZED_AGENTS
+
+            if _USE_MANIFESTS:
+                _executive_agent_shadow_candidate = _build_executive_agent_legacy(
+                    get_routing_model(), sub_agents=SPECIALIZED_AGENTS
+                )
+            else:
+                _executive_agent_shadow_candidate = (
+                    _build_executive_agent_from_manifest(
+                        get_routing_model(), sub_agents=SPECIALIZED_AGENTS
+                    )
+                )
+        return _executive_agent_shadow_candidate
 
     if name == "app":
         if _app is None:
@@ -554,5 +572,19 @@ def __getattr__(name: str):
                 ),
             )
         return _app_fallback
+
+    if name == "app_shadow_candidate":
+        if _app_shadow_candidate is None:
+            from google.adk.apps import App
+            from google.adk.apps.app import EventsCompactionConfig
+
+            _app_shadow_candidate = App(
+                root_agent=__getattr__("executive_agent_shadow_candidate"),
+                name=APP_NAME,
+                events_compaction_config=EventsCompactionConfig(
+                    compaction_interval=80, overlap_size=30
+                ),
+            )
+        return _app_shadow_candidate
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/app/fast_api_app.py
+++ b/app/fast_api_app.py
@@ -1251,7 +1251,7 @@ async def _run_shadow_candidate_for_executive(
     *,
     user_text: str,
     user_id: str,
-    primary_output: Any,
+    primary_output: object,
     request_id_str: str | None,
 ) -> None:
     """Replay ``user_text`` through the opposite executive build variant.

--- a/app/fast_api_app.py
+++ b/app/fast_api_app.py
@@ -284,8 +284,13 @@ else:
 # we only declare placeholders so downstream code can branch on `is None`.
 runner = None
 runner_fallback = None
+runner_shadow_candidate = None  # W3 Section B (B-Alpha-Plus): opposite-variant runner
 request_handler = None
-A2A_RPC_PATH = f"/a2a/{ADK_APP_NAME}" if (A2A_AVAILABLE and A2A_COMPONENTS_AVAILABLE and ADK_CORE_AVAILABLE) else None
+A2A_RPC_PATH = (
+    f"/a2a/{ADK_APP_NAME}"
+    if (A2A_AVAILABLE and A2A_COMPONENTS_AVAILABLE and ADK_CORE_AVAILABLE)
+    else None
+)
 
 
 async def _init_adk_runners() -> None:
@@ -297,6 +302,7 @@ async def _init_adk_runners() -> None:
     will see `runner is None` and respond with 503.
     """
     global adk_app, adk_app_fallback, runner, runner_fallback, request_handler
+    global runner_shadow_candidate
 
     if not ADK_CORE_AVAILABLE:
         return
@@ -329,6 +335,37 @@ async def _init_adk_runners() -> None:
             except Exception as e:
                 logger.warning(f"Fallback runner not available: {e}")
 
+        # W3 Section B (B-Alpha-Plus): build the shadow-candidate Runner
+        # with the OPPOSITE executive build path only when
+        # MANIFEST_SHADOW_PERCENT > 0. Skipping the build entirely when
+        # disabled avoids paying the ~14s agent-construction cost twice
+        # on cold starts that don't need shadow traffic.
+        _shadow_pct_startup = 0
+        try:
+            _shadow_pct_startup = int(os.getenv("MANIFEST_SHADOW_PERCENT", "0") or "0")
+        except (TypeError, ValueError):
+            _shadow_pct_startup = 0
+        if _shadow_pct_startup > 0:
+            try:
+
+                def _build_shadow():
+                    import app.agent as _agent_mod
+
+                    return _agent_mod.app_shadow_candidate
+
+                _shadow_app = await loop.run_in_executor(None, _build_shadow)
+                runner_shadow_candidate = Runner(
+                    app=_shadow_app,
+                    artifact_service=artifact_service,
+                    session_service=session_service,
+                )
+                logger.info(
+                    "[shadow] candidate runner initialized at %d%% sample rate",
+                    _shadow_pct_startup,
+                )
+            except Exception as e:
+                logger.warning("[shadow] candidate runner not available: %s", e)
+
         if A2A_AVAILABLE and A2A_COMPONENTS_AVAILABLE:
             try:
                 _task_store = SupabaseTaskStore()
@@ -359,6 +396,7 @@ async def _init_adk_runners() -> None:
         logger.info("ADK runners initialized (background task complete)")
     except Exception as e:
         logger.exception("ADK runner initialization failed: %s", e)
+
 
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
@@ -492,6 +530,8 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     try:
         from app.persistence.supabase_session_service import (
             ENABLE_CONVERSATION_SUMMARIZER as _SUMMARIZER_ENABLED,
+        )
+        from app.persistence.supabase_session_service import (
             SESSION_MAX_EVENTS as _SESSION_MAX_EVENTS,
         )
 
@@ -554,6 +594,8 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
             from app.skills.skill_embeddings import (
                 build_index as _build_skill_index,
+            )
+            from app.skills.skill_embeddings import (
                 startup_warmup_enabled as _skill_warmup_enabled,
             )
 
@@ -1084,11 +1126,11 @@ from app.routers.recruitment import router as recruitment_router
 from app.routers.reports import router as reports_router
 from app.routers.sales import router as sales_router
 from app.routers.self_improvement import router as self_improvement_router
+from app.routers.sessions import router as sessions_router
 from app.routers.suggestions import router as suggestions_router
 from app.routers.support import router as support_router
 from app.routers.teams import router as teams_router
 from app.routers.teams_public import router as teams_public_router
-from app.routers.sessions import router as sessions_router
 from app.routers.teams_rbac import router as teams_rbac_router
 from app.routers.vault import router as vault_router
 from app.routers.voice_session import router as voice_router
@@ -1198,6 +1240,147 @@ class ChatRequest(BaseModel):
     user_id: str | None = None
     new_message: NewMessage
     agent_mode: str | None = "auto"  # 'auto' | 'collab' | 'ask'
+
+
+# ---------------------------------------------------------------------------
+# W3 Section B (B-Alpha-Plus) — shadow candidate replay
+# ---------------------------------------------------------------------------
+
+
+async def _run_shadow_candidate_for_executive(
+    *,
+    user_text: str,
+    user_id: str,
+    primary_output: Any,
+    request_id_str: str | None,
+) -> None:
+    """Replay ``user_text`` through the opposite executive build variant.
+
+    Caller is fire-and-forget — this function never raises. Caps the
+    candidate stream at 90 s to bound token cost. Uses a fresh
+    ``shadow-*`` session id so the candidate's events do not pollute the
+    user's real conversation history.
+
+    Variant labels are derived from ``USE_MANIFESTS``: when manifests are
+    enabled in production, candidate is ``legacy`` (and vice versa). This
+    lets the team measure how the current production path diverges from
+    the path it's about to (or just did) replace.
+    """
+    from app.services import shadow_router as _shadow_router
+
+    if runner_shadow_candidate is None:
+        return
+
+    try:
+        shadow_sid = f"shadow-{uuid.uuid4()}"
+        await session_service.create_session(
+            app_name=ADK_APP_NAME,
+            user_id=user_id,
+            session_id=shadow_sid,
+            state={},
+        )
+        adk_msg = genai_types.Content(
+            role="user", parts=[genai_types.Part(text=user_text)]
+        )
+
+        cand_texts: list[str] = []
+        cand_tool_calls: list[dict] = []
+        cand_artifacts: list[dict] = []
+        t0 = time.monotonic()
+
+        async def _drain_candidate() -> None:
+            response_stream = runner_shadow_candidate.run_async(
+                session_id=shadow_sid,
+                new_message=adk_msg,
+                user_id=user_id,
+            )
+            async for event in response_stream:
+                if hasattr(event, "model_dump_json"):
+                    data = event.model_dump_json()
+                elif hasattr(event, "to_json"):
+                    data = event.to_json()
+                else:
+                    data = json.dumps(event, default=lambda o: str(o))
+                data = _extract_widget_from_event(data)
+                try:
+                    evt = json.loads(data)
+                    content = evt.get("content")
+                    if isinstance(content, dict):
+                        for part in content.get("parts") or []:
+                            if isinstance(part, dict):
+                                if part.get("text"):
+                                    cand_texts.append(part["text"])
+                                fn_call = part.get("function_call")
+                                if isinstance(fn_call, dict):
+                                    cand_tool_calls.append(
+                                        {
+                                            "tool_id": fn_call.get("name") or "",
+                                            "args": fn_call.get("args") or {},
+                                        }
+                                    )
+                    widget = evt.get("widget")
+                    if isinstance(widget, dict):
+                        cand_artifacts.append(
+                            {
+                                "kind": (
+                                    widget.get("type") or widget.get("kind") or "widget"
+                                ),
+                                "content_id": (
+                                    widget.get("id")
+                                    or widget.get("widget_id")
+                                    or widget.get("name")
+                                    or ""
+                                ),
+                            }
+                        )
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+        try:
+            await asyncio.wait_for(_drain_candidate(), timeout=90.0)
+        except TimeoutError:
+            logger.warning(
+                "[shadow] candidate run exceeded 90s; skipping divergence write"
+            )
+            return
+
+        candidate_output = _shadow_router.ShadowOutput(
+            text="".join(cand_texts),
+            tool_calls=cand_tool_calls,
+            artifacts=cand_artifacts,
+            latency_ms=int((time.monotonic() - t0) * 1000),
+        )
+        divergence = _shadow_router.compute_divergence(primary_output, candidate_output)
+
+        use_manifests = os.getenv("USE_MANIFESTS", "true").lower() == "true"
+        primary_variant = "manifest" if use_manifests else "legacy"
+        candidate_variant = "legacy" if use_manifests else "manifest"
+
+        request_uuid = None
+        if request_id_str:
+            try:
+                request_uuid = uuid.UUID(request_id_str)
+            except (ValueError, AttributeError, TypeError):
+                request_uuid = None
+        user_uuid = None
+        if user_id and user_id != "anonymous":
+            try:
+                user_uuid = uuid.UUID(user_id)
+            except (ValueError, AttributeError, TypeError):
+                user_uuid = None
+
+        _shadow_router.fire_and_forget_diff_write(
+            agent_id="executive",
+            primary_variant=primary_variant,
+            candidate_variant=candidate_variant,
+            primary=primary_output,
+            candidate=candidate_output,
+            divergence=divergence,
+            user_id=user_uuid,
+            request_id=request_uuid,
+        )
+    except Exception as exc:
+        logger.warning("[shadow] candidate run failed: %s", exc)
 
 
 @app.post("/a2a/app/run_sse")
@@ -1327,6 +1510,12 @@ async def run_sse(raw_request: Request, request: ChatRequest):
             _response_texts: list[str] = []
             _responding_agent: str = "EXEC"
             _had_tool_error: bool = False
+            # W3 Section B (B-Alpha-Plus) — primary's tool calls and
+            # artifact signatures, accumulated alongside _response_texts
+            # so the shadow router has something to diff the candidate
+            # output against.
+            _primary_tool_calls: list[dict] = []
+            _primary_artifacts: list[dict] = []
             # Resolved during the per-stream setup block below.
             byok_runner = None
 
@@ -1364,6 +1553,7 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                             # quota and adding ~60s of latency per request.
                             try:
                                 from app.services.model_failover import model_failover
+
                                 model_failover.record_failure()
                             except Exception:
                                 pass
@@ -1407,6 +1597,38 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                                             "error"
                                         ):
                                             _had_tool_error = True
+                                        # Shadow-router accumulator: tool
+                                        # calls issued by the primary so
+                                        # the candidate can be diffed.
+                                        fn_call = part.get("function_call")
+                                        if isinstance(fn_call, dict):
+                                            _primary_tool_calls.append(
+                                                {
+                                                    "tool_id": fn_call.get("name")
+                                                    or "",
+                                                    "args": fn_call.get("args") or {},
+                                                }
+                                            )
+                            # Shadow-router accumulator: widgets hoisted
+                            # to a top-level field by
+                            # _extract_widget_from_event above.
+                            widget = evt.get("widget")
+                            if isinstance(widget, dict):
+                                _primary_artifacts.append(
+                                    {
+                                        "kind": (
+                                            widget.get("type")
+                                            or widget.get("kind")
+                                            or "widget"
+                                        ),
+                                        "content_id": (
+                                            widget.get("id")
+                                            or widget.get("widget_id")
+                                            or widget.get("name")
+                                            or ""
+                                        ),
+                                    }
+                                )
                         except (json.JSONDecodeError, TypeError):
                             pass
 
@@ -1416,6 +1638,7 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                     # closes again after a previous quota incident.
                     try:
                         from app.services.model_failover import model_failover
+
                         model_failover.record_success()
                     except Exception:
                         pass
@@ -1429,6 +1652,7 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                     if is_quota:
                         try:
                             from app.services.model_failover import model_failover
+
                             model_failover.record_failure()
                         except Exception:
                             pass
@@ -1440,7 +1664,9 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                             "gemini-2.5-flash to use the higher-quota model."
                         )
                         await adk_event_queue.put(
-                            json.dumps({"error": user_msg, "error_code": "quota_exhausted"})
+                            json.dumps(
+                                {"error": user_msg, "error_code": "quota_exhausted"}
+                            )
                         )
                     else:
                         await adk_event_queue.put(json.dumps({"error": str(e)}))
@@ -1467,9 +1693,7 @@ async def run_sse(raw_request: Request, request: ChatRequest):
 
                 # 1. Ensure session exists and preload personalization state.
                 try:
-                    state_updates: dict[str, object] = {
-                        "user_id": effective_user_id
-                    }
+                    state_updates: dict[str, object] = {"user_id": effective_user_id}
                     if effective_user_id != "anonymous":
                         try:
                             from app.services.user_agent_factory import (
@@ -1477,14 +1701,12 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                                 get_user_agent_factory,
                             )
 
-                            personalization = (
-                                await get_user_agent_factory().get_runtime_personalization(
-                                    effective_user_id
-                                )
+                            personalization = await get_user_agent_factory().get_runtime_personalization(
+                                effective_user_id
                             )
-                            state_updates[
-                                USER_AGENT_PERSONALIZATION_STATE_KEY
-                            ] = personalization
+                            state_updates[USER_AGENT_PERSONALIZATION_STATE_KEY] = (
+                                personalization
+                            )
                         except Exception as personalization_error:
                             logger.warning(
                                 "User personalization preload failed for %s: %s",
@@ -1510,9 +1732,7 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                             state=state_updates,
                         )
                     else:
-                        current_state = (
-                            getattr(existing_session, "state", {}) or {}
-                        )
+                        current_state = getattr(existing_session, "state", {}) or {}
                         needs_update = any(
                             current_state.get(key) != value
                             for key, value in state_updates.items()
@@ -1548,9 +1768,7 @@ async def run_sse(raw_request: Request, request: ChatRequest):
                             f"Loaded {loaded_count} custom skills for user {effective_user_id}"
                         )
                 except Exception as e:
-                    logger.warning(
-                        f"Custom skill loading failed (non-fatal): {e}"
-                    )
+                    logger.warning(f"Custom skill loading failed (non-fatal): {e}")
 
                 yield ": setup\n\n"
 
@@ -1629,6 +1847,48 @@ async def run_sse(raw_request: Request, request: ChatRequest):
 
                 if runner_task is not None:
                     await runner_task
+
+                # W3 Section B (B-Alpha-Plus) — schedule a shadow run of
+                # the opposite executive variant when the runner exists
+                # and the configured percent fires. Fire-and-forget: the
+                # primary stream has already finished, so the user sees
+                # no extra latency from this.
+                if runner_shadow_candidate is not None:
+                    try:
+                        from app.services import shadow_router as _sr
+
+                        _shadow_pct = int(
+                            os.getenv("MANIFEST_SHADOW_PERCENT", "0") or "0"
+                        )
+                    except (TypeError, ValueError):
+                        _shadow_pct = 0
+                    if _sr.should_shadow(_shadow_pct):
+                        _primary_output = _sr.ShadowOutput(
+                            text="".join(_response_texts),
+                            tool_calls=list(_primary_tool_calls),
+                            artifacts=list(_primary_artifacts),
+                            latency_ms=int(
+                                (time.monotonic() - stream_start_time) * 1000
+                            ),
+                        )
+                        _shadow_task = asyncio.create_task(
+                            _run_shadow_candidate_for_executive(
+                                user_text=user_text,
+                                user_id=effective_user_id,
+                                primary_output=_primary_output,
+                                request_id_str=request.session_id,
+                            )
+                        )
+                        _shadow_task.add_done_callback(
+                            lambda t: (
+                                logger.warning(
+                                    "[shadow] task ended with exception: %s",
+                                    t.exception(),
+                                )
+                                if (not t.cancelled() and t.exception() is not None)
+                                else None
+                            )
+                        )
 
                 # Synthesize a markdown_report widget from the accumulated
                 # agent text when the reply is longform enough to be worth

--- a/app/services/shadow_router.py
+++ b/app/services/shadow_router.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+# Proprietary and confidential. See LICENSE file for details.
+
+"""Shadow-traffic router helpers for W3 Section B (B-Alpha-Plus).
+
+This module provides the building blocks for shadowing a primary agent
+variant against a candidate variant and persisting their divergence into
+``public.agent_shadow_diffs`` for offline review.
+
+The surface is intentionally functional (not a class) — each helper is
+independently composable from the FastAPI run_sse hook that wires shadow
+traffic. See ``project_agent_operating_model_w1.md`` (memory) for the
+design decisions resolved before implementation.
+
+Key contracts:
+    * ``compute_divergence`` is a pure function over normalized inputs;
+      it does not touch I/O.
+    * ``should_shadow`` is a cheap, defensive sampler; non-int inputs do
+      not crash callers.
+    * ``write_shadow_diff`` is fire-and-forget from the caller's view —
+      it swallows every exception and logs a warning. It MUST NEVER raise.
+    * ``fire_and_forget_diff_write`` schedules the write via
+      ``asyncio.create_task`` so the caller can keep going.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import logging
+import random
+import re
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ShadowOutput:
+    """Captured final output of a single agent variant for a turn.
+
+    Attributes:
+        text: User-facing rendered text.
+        tool_calls: List of ``{"tool_id": str, "args": dict}`` records.
+        artifacts: List of ``{"kind": str, "content_id": str}`` records.
+            Additional fields are tolerated and ignored by the divergence
+            computation.
+        latency_ms: Wall-clock duration from request start to last event.
+    """
+
+    text: str = ""
+    tool_calls: list[dict] = field(default_factory=list)
+    artifacts: list[dict] = field(default_factory=list)
+    latency_ms: int | None = None
+
+
+@dataclass
+class Divergence:
+    """Comparison result between a primary and candidate :class:`ShadowOutput`.
+
+    Attributes:
+        score: Overall divergence in ``[0.0, 1.0]``; the max of the three
+            dimension scores. ``0.0`` means identical, ``1.0`` means fully
+            divergent.
+        kind: One of ``"identical"``, ``"text"``, ``"tool_calls"``,
+            ``"artifacts"``, or ``"multiple"``.
+        text_score: Jaccard distance over normalized text tokens.
+        tool_calls_score: Jaccard distance over tool-call signatures.
+        artifacts_score: Jaccard distance over ``(kind, content_id)`` tuples.
+    """
+
+    score: float
+    kind: str
+    text_score: float
+    tool_calls_score: float
+    artifacts_score: float
+
+
+# ---------------------------------------------------------------------------
+# Divergence
+# ---------------------------------------------------------------------------
+
+# A dimension counts as "agreed" if its score is below this threshold.
+# Float noise from set arithmetic stays nowhere near 0.05, but if we
+# upgrade to embedding-based similarity later the threshold becomes
+# load-bearing.
+_AGREEMENT_THRESHOLD = 0.05
+
+_TOKEN_RE = re.compile(r"\w+")
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase, strip punctuation, drop tokens of length < 2."""
+    if not text:
+        return set()
+    return {tok for tok in _TOKEN_RE.findall(text.lower()) if len(tok) >= 2}
+
+
+def _jaccard_distance(a: set[Any], b: set[Any]) -> float:
+    """Return Jaccard distance ``1 - intersection/union``. Empty sets -> 0.0."""
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return 1.0 - (len(a & b) / len(union))
+
+
+def _tool_call_signatures(calls: list[dict]) -> set[tuple[str, str]]:
+    """Project tool calls onto stable ``(tool_id, sorted-json-args)`` keys."""
+    signatures: set[tuple[str, str]] = set()
+    for call in calls or []:
+        tool_id = str(call.get("tool_id", ""))
+        args = call.get("args", {}) or {}
+        try:
+            args_key = json.dumps(args, sort_keys=True, default=str)
+        except (TypeError, ValueError):
+            # Last-ditch fallback for un-serializable arg payloads; we
+            # would rather record *something* than crash divergence.
+            args_key = repr(args)
+        signatures.add((tool_id, args_key))
+    return signatures
+
+
+def _artifact_signatures(artifacts: list[dict]) -> set[tuple[str, str]]:
+    """Project artifacts onto stable ``(kind, content_id)`` keys."""
+    signatures: set[tuple[str, str]] = set()
+    for art in artifacts or []:
+        kind = str(art.get("kind", ""))
+        content_id = str(art.get("content_id", art.get("id", "")))
+        signatures.add((kind, content_id))
+    return signatures
+
+
+def _classify_kind(
+    text_score: float,
+    tool_calls_score: float,
+    artifacts_score: float,
+) -> str:
+    """Map per-dimension scores to the discriminated ``kind`` label."""
+    disagreements: list[str] = []
+    if text_score >= _AGREEMENT_THRESHOLD:
+        disagreements.append("text")
+    if tool_calls_score >= _AGREEMENT_THRESHOLD:
+        disagreements.append("tool_calls")
+    if artifacts_score >= _AGREEMENT_THRESHOLD:
+        disagreements.append("artifacts")
+
+    if not disagreements:
+        return "identical"
+    if len(disagreements) == 1:
+        return disagreements[0]
+    return "multiple"
+
+
+def compute_divergence(primary: ShadowOutput, candidate: ShadowOutput) -> Divergence:
+    """Compute a :class:`Divergence` between two :class:`ShadowOutput` values.
+
+    Uses simple set-based Jaccard distance across three dimensions
+    (text tokens, tool-call signatures, artifact identifiers). The
+    overall score is the max of the three dimension scores; ``kind``
+    summarizes which dimension(s) disagreed.
+
+    Args:
+        primary: The primary variant's output.
+        candidate: The candidate variant's output.
+
+    Returns:
+        A :class:`Divergence` instance.
+    """
+    text_score = _jaccard_distance(_tokenize(primary.text), _tokenize(candidate.text))
+    tool_calls_score = _jaccard_distance(
+        _tool_call_signatures(primary.tool_calls),
+        _tool_call_signatures(candidate.tool_calls),
+    )
+    artifacts_score = _jaccard_distance(
+        _artifact_signatures(primary.artifacts),
+        _artifact_signatures(candidate.artifacts),
+    )
+
+    overall = max(text_score, tool_calls_score, artifacts_score)
+    kind = _classify_kind(text_score, tool_calls_score, artifacts_score)
+
+    return Divergence(
+        score=overall,
+        kind=kind,
+        text_score=text_score,
+        tool_calls_score=tool_calls_score,
+        artifacts_score=artifacts_score,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Traffic sampling
+# ---------------------------------------------------------------------------
+
+
+def should_shadow(percent: int) -> bool:
+    """Return True for ``random.randint(0, 99) < percent``.
+
+    Defensive against bad input — non-int inputs return ``False`` and
+    out-of-range percents are clamped to ``[0, 100]``.
+
+    Args:
+        percent: Desired shadow rate in ``[0, 100]``.
+
+    Returns:
+        Whether this call should shadow the request.
+    """
+    if not isinstance(percent, int) or isinstance(percent, bool):
+        # bool is a subclass of int; we explicitly reject it because
+        # ``True``/``False`` would otherwise be treated as 1/0 and quietly
+        # work, masking caller bugs.
+        if isinstance(percent, bool):
+            # Allow bool through as int after all? No — caller should pass
+            # int. Reject to match spec.
+            return False
+        return False
+
+    clamped = max(0, min(100, percent))
+    if clamped <= 0:
+        return False
+    if clamped >= 100:
+        return True
+    return random.randint(0, 99) < clamped
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _get_supabase() -> Any:
+    """Return the async Supabase client (or a coroutine producing one).
+
+    Tests monkeypatch this to a sync ``lambda`` returning a ``MagicMock``;
+    production hits ``get_async_client()`` which is itself a coroutine.
+    Both shapes are handled by :func:`_resolve_supabase`.
+    """
+    from app.services.supabase_client import get_async_client
+
+    return get_async_client()
+
+
+async def _resolve_supabase() -> Any:
+    """Resolve ``_get_supabase()`` whether sync- or coroutine-returning."""
+    candidate = _get_supabase()
+    if inspect.iscoroutine(candidate):
+        return await candidate
+    return candidate
+
+
+def _build_record(
+    *,
+    agent_id: str,
+    primary_variant: str,
+    candidate_variant: str,
+    primary: ShadowOutput,
+    candidate: ShadowOutput,
+    divergence: Divergence,
+    user_id: UUID | None,
+    request_id: UUID | None,
+) -> dict[str, Any]:
+    """Assemble the insertable row for ``agent_shadow_diffs``."""
+    record: dict[str, Any] = {
+        "agent_id": agent_id,
+        "primary_variant": primary_variant,
+        "candidate_variant": candidate_variant,
+        "primary_text": primary.text,
+        "candidate_text": candidate.text,
+        "primary_tool_calls": list(primary.tool_calls or []),
+        "candidate_tool_calls": list(candidate.tool_calls or []),
+        "primary_artifacts": list(primary.artifacts or []),
+        "candidate_artifacts": list(candidate.artifacts or []),
+        "divergence_score": float(divergence.score),
+        "divergence_kind": divergence.kind,
+        "primary_latency_ms": primary.latency_ms,
+        "candidate_latency_ms": candidate.latency_ms,
+    }
+    if user_id is not None:
+        record["user_id"] = str(user_id)
+    if request_id is not None:
+        record["request_id"] = str(request_id)
+    return record
+
+
+async def write_shadow_diff(
+    *,
+    agent_id: str,
+    primary_variant: str,
+    candidate_variant: str,
+    primary: ShadowOutput,
+    candidate: ShadowOutput,
+    divergence: Divergence,
+    user_id: UUID | None = None,
+    request_id: UUID | None = None,
+) -> None:
+    """Insert one row into ``public.agent_shadow_diffs``.
+
+    Swallows every exception (network, schema, serialization) and logs a
+    warning. The caller MUST be able to treat this as fire-and-forget.
+
+    Args:
+        agent_id: TEXT id of the shadowed agent (e.g. ``"executive"``).
+        primary_variant: Name of the primary build path (e.g. ``"legacy"``).
+        candidate_variant: Name of the candidate build path
+            (e.g. ``"manifest"``).
+        primary: The primary variant's :class:`ShadowOutput`.
+        candidate: The candidate variant's :class:`ShadowOutput`.
+        divergence: Pre-computed :class:`Divergence` between the two.
+        user_id: Optional user UUID for ``auth.users(id)`` FK.
+        request_id: Optional correlation UUID for the original turn.
+    """
+    try:
+        client = await _resolve_supabase()
+        record = _build_record(
+            agent_id=agent_id,
+            primary_variant=primary_variant,
+            candidate_variant=candidate_variant,
+            primary=primary,
+            candidate=candidate,
+            divergence=divergence,
+            user_id=user_id,
+            request_id=request_id,
+        )
+        await client.table("agent_shadow_diffs").insert(record).execute()
+    except Exception as exc:
+        logger.warning("[shadow_router] write_shadow_diff failed: %s", exc)
+
+
+def fire_and_forget_diff_write(
+    *,
+    agent_id: str,
+    primary_variant: str,
+    candidate_variant: str,
+    primary: ShadowOutput,
+    candidate: ShadowOutput,
+    divergence: Divergence,
+    user_id: UUID | None = None,
+    request_id: UUID | None = None,
+) -> asyncio.Task[None]:
+    """Schedule :func:`write_shadow_diff` on the current event loop.
+
+    Returns the resulting :class:`asyncio.Task` so callers can hold a
+    reference (asyncio garbage-collects orphan tasks) or cancel during
+    shutdown. The task itself never raises because
+    :func:`write_shadow_diff` swallows exceptions internally.
+
+    Args:
+        agent_id: See :func:`write_shadow_diff`.
+        primary_variant: See :func:`write_shadow_diff`.
+        candidate_variant: See :func:`write_shadow_diff`.
+        primary: See :func:`write_shadow_diff`.
+        candidate: See :func:`write_shadow_diff`.
+        divergence: See :func:`write_shadow_diff`.
+        user_id: See :func:`write_shadow_diff`.
+        request_id: See :func:`write_shadow_diff`.
+
+    Returns:
+        The created :class:`asyncio.Task`.
+    """
+    return asyncio.create_task(
+        write_shadow_diff(
+            agent_id=agent_id,
+            primary_variant=primary_variant,
+            candidate_variant=candidate_variant,
+            primary=primary,
+            candidate=candidate,
+            divergence=divergence,
+            user_id=user_id,
+            request_id=request_id,
+        )
+    )

--- a/supabase/migrations/20260511140000_agent_shadow_diffs.sql
+++ b/supabase/migrations/20260511140000_agent_shadow_diffs.sql
@@ -1,0 +1,55 @@
+-- supabase/migrations/20260511140000_agent_shadow_diffs.sql
+--
+-- Agent Operating Model — W3 Section B (B-Alpha-Plus)
+-- Shadow-traffic divergence records: one row per shadow turn comparing a
+-- primary agent variant against a candidate variant. Powers an offline
+-- review of how the manifest path diverges from the legacy executive
+-- path (and any future A/B comparisons we wire through the shadow
+-- router).
+--
+-- Reads are admin/service-role only in v1; no user-facing surface yet.
+
+CREATE TABLE IF NOT EXISTS public.agent_shadow_diffs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    agent_id TEXT NOT NULL,
+    request_id UUID,
+    user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    primary_variant TEXT NOT NULL,
+    candidate_variant TEXT NOT NULL,
+    primary_text TEXT,
+    candidate_text TEXT,
+    primary_tool_calls JSONB NOT NULL DEFAULT '[]'::jsonb,
+    candidate_tool_calls JSONB NOT NULL DEFAULT '[]'::jsonb,
+    primary_artifacts JSONB NOT NULL DEFAULT '[]'::jsonb,
+    candidate_artifacts JSONB NOT NULL DEFAULT '[]'::jsonb,
+    divergence_score DOUBLE PRECISION NOT NULL DEFAULT 0.0
+        CHECK (divergence_score >= 0.0 AND divergence_score <= 1.0),
+    divergence_kind TEXT NOT NULL
+        CHECK (divergence_kind IN ('identical','text','tool_calls','artifacts','multiple')),
+    primary_latency_ms INTEGER,
+    candidate_latency_ms INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_asd_created
+    ON public.agent_shadow_diffs (created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_asd_agent_created
+    ON public.agent_shadow_diffs (agent_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_asd_kind_created
+    ON public.agent_shadow_diffs (divergence_kind, created_at DESC)
+    WHERE divergence_kind <> 'identical';
+
+ALTER TABLE public.agent_shadow_diffs ENABLE ROW LEVEL SECURITY;
+
+-- No authenticated-user reads in v1. Service role bypasses RLS and is
+-- the only writer (background fire-and-forget task in run_sse). When a
+-- user-facing admin view lands, add a policy gated on a role check.
+DROP POLICY IF EXISTS "agent_shadow_diffs_service_only"
+    ON public.agent_shadow_diffs;
+CREATE POLICY "agent_shadow_diffs_service_only"
+    ON public.agent_shadow_diffs
+    FOR ALL
+    USING (false)
+    WITH CHECK (false);

--- a/tests/unit/services/test_shadow_router.py
+++ b/tests/unit/services/test_shadow_router.py
@@ -1,0 +1,449 @@
+# Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+# Proprietary and confidential. See LICENSE file for details.
+
+"""Unit tests for ``app.services.shadow_router``.
+
+Covers the three divergence dimensions (text / tool_calls / artifacts),
+the ``should_shadow`` sampler, and the fire-and-forget Supabase
+persistence. See ``project_agent_operating_model_w1.md`` for design
+context.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.services import shadow_router
+from app.services.shadow_router import (
+    ShadowOutput,
+    compute_divergence,
+    fire_and_forget_diff_write,
+    should_shadow,
+    write_shadow_diff,
+)
+
+# ---------------------------------------------------------------------------
+# compute_divergence — text dimension
+# ---------------------------------------------------------------------------
+
+
+def test_compute_divergence_identical_text_returns_zero() -> None:
+    primary = ShadowOutput(text="The quick brown fox jumps over the lazy dog.")
+    candidate = ShadowOutput(text="The quick brown fox jumps over the lazy dog.")
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score == 0.0
+    assert div.kind == "identical"
+    assert div.score == 0.0
+
+
+def test_compute_divergence_completely_different_text_returns_one() -> None:
+    primary = ShadowOutput(text="alpha beta gamma delta")
+    candidate = ShadowOutput(text="omega psi chi phi")
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score == 1.0
+    assert div.kind == "text"
+    assert div.score == 1.0
+
+
+def test_compute_divergence_partial_text_overlap() -> None:
+    # Two of four tokens overlap → Jaccard distance is strictly between 0 and 1.
+    primary = ShadowOutput(text="alpha beta gamma delta")
+    candidate = ShadowOutput(text="alpha beta epsilon zeta")
+
+    div = compute_divergence(primary, candidate)
+
+    assert 0.0 < div.text_score < 1.0
+
+
+def test_compute_divergence_empty_both_texts_treated_as_identical() -> None:
+    primary = ShadowOutput(text="")
+    candidate = ShadowOutput(text="")
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score == 0.0
+    assert div.kind == "identical"
+
+
+def test_compute_divergence_one_empty_text() -> None:
+    primary = ShadowOutput(text="")
+    candidate = ShadowOutput(text="alpha beta gamma")
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score == 1.0
+    assert div.kind == "text"
+
+
+def test_compute_divergence_text_normalizes_case_and_punctuation() -> None:
+    primary = ShadowOutput(text="Hello, world!")
+    candidate = ShadowOutput(text="hello world")
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score == 0.0
+    assert div.kind == "identical"
+
+
+def test_compute_divergence_text_skips_short_tokens() -> None:
+    # Length-1 tokens ("I") must be dropped before computing similarity.
+    # primary tokens (>=2): {"am", "here"}; candidate tokens: {"you", "are", "here"}.
+    # Intersection: {"here"} (1); union: {"am", "here", "you", "are"} (4).
+    # Distance: 1 - 1/4 = 0.75.
+    primary = ShadowOutput(text="I am here")
+    candidate = ShadowOutput(text="you are here")
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score == pytest.approx(0.75)
+
+
+# ---------------------------------------------------------------------------
+# compute_divergence — tool_calls dimension
+# ---------------------------------------------------------------------------
+
+
+def test_compute_divergence_tool_calls_same_multiset_zero_regardless_of_order() -> None:
+    call_a = {"tool_id": "search_web", "args": {"query": "hello"}}
+    call_b = {"tool_id": "send_email", "args": {"to": "a@b.com", "body": "hi"}}
+
+    primary = ShadowOutput(tool_calls=[call_a, call_b])
+    candidate = ShadowOutput(tool_calls=[call_b, call_a])
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.tool_calls_score == 0.0
+
+
+def test_compute_divergence_tool_calls_different_args_diverge() -> None:
+    primary = ShadowOutput(
+        tool_calls=[{"tool_id": "search_web", "args": {"query": "alpha"}}]
+    )
+    candidate = ShadowOutput(
+        tool_calls=[{"tool_id": "search_web", "args": {"query": "beta"}}]
+    )
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.tool_calls_score > 0.0
+
+
+def test_compute_divergence_tool_calls_subset_partial_score() -> None:
+    # Primary has two calls, candidate has one of them.
+    call_a = {"tool_id": "search_web", "args": {"query": "hello"}}
+    call_b = {"tool_id": "send_email", "args": {"to": "x@y.com"}}
+
+    primary = ShadowOutput(tool_calls=[call_a, call_b])
+    candidate = ShadowOutput(tool_calls=[call_a])
+
+    div = compute_divergence(primary, candidate)
+
+    assert 0.0 < div.tool_calls_score < 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_divergence — artifacts dimension
+# ---------------------------------------------------------------------------
+
+
+def test_compute_divergence_artifacts_same_set_zero() -> None:
+    primary = ShadowOutput(
+        artifacts=[
+            {"kind": "chart", "content_id": "abc"},
+            {"kind": "doc", "content_id": "def"},
+        ]
+    )
+    candidate = ShadowOutput(
+        artifacts=[
+            {"kind": "doc", "content_id": "def"},
+            {"kind": "chart", "content_id": "abc"},
+        ]
+    )
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.artifacts_score == 0.0
+
+
+def test_compute_divergence_artifacts_disjoint_one() -> None:
+    primary = ShadowOutput(artifacts=[{"kind": "chart", "content_id": "abc"}])
+    candidate = ShadowOutput(artifacts=[{"kind": "chart", "content_id": "xyz"}])
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.artifacts_score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# compute_divergence — overall score + kind
+# ---------------------------------------------------------------------------
+
+
+def test_compute_divergence_overall_score_is_max_of_dimensions() -> None:
+    # text fully diverges (1.0), tool_calls and artifacts agree (0.0).
+    primary = ShadowOutput(
+        text="alpha beta",
+        tool_calls=[{"tool_id": "noop", "args": {}}],
+        artifacts=[{"kind": "doc", "content_id": "1"}],
+    )
+    candidate = ShadowOutput(
+        text="omega psi",
+        tool_calls=[{"tool_id": "noop", "args": {}}],
+        artifacts=[{"kind": "doc", "content_id": "1"}],
+    )
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score == 1.0
+    assert div.tool_calls_score == 0.0
+    assert div.artifacts_score == 0.0
+    assert div.score == 1.0
+    assert div.kind == "text"
+
+
+def test_compute_divergence_multiple_dimensions_diverge_yields_multiple_kind() -> None:
+    primary = ShadowOutput(
+        text="alpha beta",
+        tool_calls=[{"tool_id": "search_web", "args": {"q": "alpha"}}],
+        artifacts=[{"kind": "doc", "content_id": "1"}],
+    )
+    candidate = ShadowOutput(
+        text="omega psi",
+        tool_calls=[{"tool_id": "send_email", "args": {"to": "x@y.com"}}],
+        artifacts=[{"kind": "doc", "content_id": "1"}],
+    )
+
+    div = compute_divergence(primary, candidate)
+
+    assert div.text_score > 0
+    assert div.tool_calls_score > 0
+    assert div.kind == "multiple"
+
+
+# ---------------------------------------------------------------------------
+# should_shadow
+# ---------------------------------------------------------------------------
+
+
+def test_should_shadow_zero_percent_never_returns_true() -> None:
+    assert not any(should_shadow(0) for _ in range(1000))
+
+
+def test_should_shadow_hundred_percent_always_returns_true() -> None:
+    assert all(should_shadow(100) for _ in range(1000))
+
+
+def test_should_shadow_fifty_percent_roughly_half_true() -> None:
+    random.seed(42)  # Stabilize against rare CI flakes.
+    count_true = sum(1 for _ in range(1000) if should_shadow(50))
+    assert 400 < count_true < 600
+
+
+def test_should_shadow_clamps_out_of_range_percent() -> None:
+    assert not any(should_shadow(-5) for _ in range(100))
+    assert all(should_shadow(150) for _ in range(100))
+
+
+@pytest.mark.parametrize("bad_input", ["10", None, 0.5, 50.0, [], {}, object()])
+def test_should_shadow_rejects_non_int_input(bad_input) -> None:
+    # Must not raise; must return False for everything that isn't a plain int.
+    assert should_shadow(bad_input) is False
+
+
+def test_should_shadow_rejects_bool_input() -> None:
+    # ``bool`` is a subclass of int in Python; we explicitly reject it
+    # so callers can't accidentally pass True/False and get 100%/0%.
+    assert should_shadow(True) is False
+    assert should_shadow(False) is False
+
+
+# ---------------------------------------------------------------------------
+# write_shadow_diff + fire_and_forget_diff_write
+# ---------------------------------------------------------------------------
+
+
+def _make_supabase_mock() -> tuple[MagicMock, MagicMock]:
+    """Return ``(client, table_mock)`` shaped like a Supabase async client."""
+    insert_mock = MagicMock()
+    insert_mock.execute = AsyncMock(return_value=MagicMock(data=[{"id": "row-1"}]))
+    table_mock = MagicMock(insert=MagicMock(return_value=insert_mock))
+    client = MagicMock(table=MagicMock(return_value=table_mock))
+    return client, table_mock
+
+
+@pytest.mark.asyncio
+async def test_write_shadow_diff_calls_supabase_insert_with_record(
+    monkeypatch,
+) -> None:
+    client, table_mock = _make_supabase_mock()
+    monkeypatch.setattr(shadow_router, "_get_supabase", lambda: client)
+
+    user_id = uuid4()
+    request_id = uuid4()
+
+    primary = ShadowOutput(
+        text="hello",
+        tool_calls=[{"tool_id": "noop", "args": {}}],
+        artifacts=[{"kind": "doc", "content_id": "1"}],
+        latency_ms=120,
+    )
+    candidate = ShadowOutput(
+        text="hi",
+        tool_calls=[],
+        artifacts=[],
+        latency_ms=150,
+    )
+    divergence = compute_divergence(primary, candidate)
+
+    await write_shadow_diff(
+        agent_id="executive",
+        primary_variant="legacy",
+        candidate_variant="manifest",
+        primary=primary,
+        candidate=candidate,
+        divergence=divergence,
+        user_id=user_id,
+        request_id=request_id,
+    )
+
+    # Insert was issued against the correct table with the expected fields.
+    assert client.table.call_args[0][0] == "agent_shadow_diffs"
+    payload = table_mock.insert.call_args[0][0]
+    assert payload["agent_id"] == "executive"
+    assert payload["primary_variant"] == "legacy"
+    assert payload["candidate_variant"] == "manifest"
+    assert payload["primary_text"] == "hello"
+    assert payload["candidate_text"] == "hi"
+    assert payload["primary_tool_calls"] == [{"tool_id": "noop", "args": {}}]
+    assert payload["candidate_tool_calls"] == []
+    assert payload["primary_artifacts"] == [{"kind": "doc", "content_id": "1"}]
+    assert payload["candidate_artifacts"] == []
+    assert payload["divergence_score"] == divergence.score
+    assert payload["divergence_kind"] == divergence.kind
+    assert payload["primary_latency_ms"] == 120
+    assert payload["candidate_latency_ms"] == 150
+    assert payload["user_id"] == str(user_id)
+    assert payload["request_id"] == str(request_id)
+
+
+@pytest.mark.asyncio
+async def test_write_shadow_diff_omits_optional_ids_when_absent(
+    monkeypatch,
+) -> None:
+    client, table_mock = _make_supabase_mock()
+    monkeypatch.setattr(shadow_router, "_get_supabase", lambda: client)
+
+    primary = ShadowOutput(text="a")
+    candidate = ShadowOutput(text="a")
+    divergence = compute_divergence(primary, candidate)
+
+    await write_shadow_diff(
+        agent_id="executive",
+        primary_variant="legacy",
+        candidate_variant="manifest",
+        primary=primary,
+        candidate=candidate,
+        divergence=divergence,
+    )
+
+    payload = table_mock.insert.call_args[0][0]
+    # Schema treats user_id/request_id as nullable; we omit the keys
+    # entirely when not provided so Supabase uses the column defaults.
+    assert "user_id" not in payload
+    assert "request_id" not in payload
+
+
+@pytest.mark.asyncio
+async def test_write_shadow_diff_swallows_supabase_exception(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    insert_mock = MagicMock()
+    insert_mock.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    table_mock = MagicMock(insert=MagicMock(return_value=insert_mock))
+    client = MagicMock(table=MagicMock(return_value=table_mock))
+    monkeypatch.setattr(shadow_router, "_get_supabase", lambda: client)
+
+    primary = ShadowOutput(text="a")
+    candidate = ShadowOutput(text="b")
+    divergence = compute_divergence(primary, candidate)
+
+    with caplog.at_level(logging.WARNING, logger=shadow_router.logger.name):
+        result = await write_shadow_diff(
+            agent_id="executive",
+            primary_variant="legacy",
+            candidate_variant="manifest",
+            primary=primary,
+            candidate=candidate,
+            divergence=divergence,
+        )
+
+    assert result is None
+    assert any(
+        "write_shadow_diff failed" in rec.getMessage() and "boom" in rec.getMessage()
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_shadow_diff_swallows_client_acquisition_error(
+    monkeypatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Even if obtaining the client raises, the helper must not propagate."""
+
+    def explode() -> None:
+        raise RuntimeError("no client today")
+
+    monkeypatch.setattr(shadow_router, "_get_supabase", explode)
+
+    primary = ShadowOutput(text="a")
+    candidate = ShadowOutput(text="b")
+    divergence = compute_divergence(primary, candidate)
+
+    with caplog.at_level(logging.WARNING, logger=shadow_router.logger.name):
+        await write_shadow_diff(
+            agent_id="executive",
+            primary_variant="legacy",
+            candidate_variant="manifest",
+            primary=primary,
+            candidate=candidate,
+            divergence=divergence,
+        )
+
+    assert any("write_shadow_diff failed" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_diff_write_returns_task_immediately(
+    monkeypatch,
+) -> None:
+    client, _ = _make_supabase_mock()
+    monkeypatch.setattr(shadow_router, "_get_supabase", lambda: client)
+
+    primary = ShadowOutput(text="a")
+    candidate = ShadowOutput(text="a")
+    divergence = compute_divergence(primary, candidate)
+
+    task = fire_and_forget_diff_write(
+        agent_id="executive",
+        primary_variant="legacy",
+        candidate_variant="manifest",
+        primary=primary,
+        candidate=candidate,
+        divergence=divergence,
+    )
+
+    assert isinstance(task, asyncio.Task)
+    # Awaiting the task must not raise — write_shadow_diff swallows all.
+    await task
+    assert task.done()
+    assert task.exception() is None


### PR DESCRIPTION
## Summary

Ships **W3 Section B** per the **B-Alpha-Plus** path documented in the W3 plan: shadow-traffic infrastructure that compares the in-flight manifest executive build against the legacy path. Per the survey in PR #27, we deliberately **do NOT migrate executive to PikarBaseAgent** in this PR — that would create a third agent-config system alongside AgentManifest and operations.yaml. This PR instead validates the existing manifest migration with real divergence data.

Two commits:
- \`f91cf2dd\` — shadow router helpers + migration + 31 unit tests
- \`a6210a0a\` — wiring into run_sse + opposite-variant lazy app in app/agent.py

## What ships

### Helpers — \`app/services/shadow_router.py\` + 31 tests

- \`ShadowOutput\`, \`Divergence\` dataclasses.
- \`compute_divergence()\` — pure function, Jaccard distance over text tokens, tool-call signatures (\`tool_id\` + sort_keys'd args JSON), and \`(kind, content_id)\` artifact tuples. \`score = max\` of the three dimensions. \`kind\` names which dimension(s) diverged.
- \`should_shadow(percent)\` — defensive sampler; clamps to \`[0,100]\`, rejects non-int (including bool subclass) inputs.
- \`write_shadow_diff()\` / \`fire_and_forget_diff_write()\` — persistence via the existing \`supabase_client.get_async_client\` singleton. Swallows every exception — never raises in the caller's path.

### Migration — \`supabase/migrations/20260511140000_agent_shadow_diffs.sql\`

- Columns: \`agent_id\`, \`primary_variant\`, \`candidate_variant\`, texts, tool_calls, artifacts, divergence_score, divergence_kind, latencies.
- RLS enabled with a service-role-only policy. No user-facing reads in v1.
- Indexes on \`(created_at desc)\`, \`(agent_id, created_at desc)\`, and a partial index on \`(divergence_kind, created_at desc) WHERE divergence_kind <> 'identical'\` so the divergence dashboard can query non-identical rows efficiently.

### Wiring — \`app/agent.py\` + \`app/fast_api_app.py\`

- \`app.agent\` now lazily exposes \`executive_agent_shadow_candidate\` and \`app_shadow_candidate\` — the **opposite variant** of whatever \`USE_MANIFESTS\` resolves to. Lazy so cold starts don't build both unless shadow is enabled.
- \`app/fast_api_app.py\` adds \`runner_shadow_candidate\` (built at startup when \`MANIFEST_SHADOW_PERCENT > 0\`). \`_run_shadow_candidate_for_executive\` replays the user message through the candidate runner with a fresh \`shadow-{uuid}\` session id (history-isolation; primary's session is never touched). Capped at 90s via \`asyncio.wait_for\` to bound cost.
- \`run_sse\` accumulates \`_primary_tool_calls\` and \`_primary_artifacts\` alongside the existing \`_response_texts\` so the shadow router has something to diff. Schedules the candidate via \`asyncio.create_task\` after the primary stream completes — fire-and-forget; the user sees no extra latency.

## Config

| Env var | Default | Effect |
|---|---|---|
| \`MANIFEST_SHADOW_PERCENT\` | \`0\` | When \`0\`, no candidate runner is built and no shadow traffic flows (zero cost). \`1-100\` enables shadow sampling at that percentage of executive turns. |
| \`USE_MANIFESTS\` | \`true\` (existing) | Determines which variant is \"primary\" — the other becomes the shadow candidate. |

## Limitations (documented for follow-up)

- Candidate uses a fresh session, so **conversation-history-dependent divergences are invisible to v1**. Acceptable for measuring routing / tool-selection divergence between legacy and manifest paths.
- \`divergence_kind\` enum excludes \`'timeout'\` — timeouts log and skip the write. If timeout rate becomes interesting, add the enum value and surface it.
- Divergence uses cheap text similarity (Jaccard on tokens). Upgrade to Vertex embeddings later if false-positive rate is high.
- The wiring helper \`_run_shadow_candidate_for_executive\` is not unit-tested at the FastAPI layer — it depends on \`runner_shadow_candidate\` + \`session_service\` + \`genai_types\` module globals, which makes unit mocking expensive. The 31 unit tests cover the pure helpers; integration validation comes from staging with \`MANIFEST_SHADOW_PERCENT=10\`.

## Test plan

- [x] \`uv run pytest tests/unit/services/test_shadow_router.py tests/unit/agents tests/integration/agents\` — **456 passing**.
- [x] \`uv run ruff check\` — clean on all touched code (pre-existing E402s in \`fast_api_app.py\` from intentional \`load_dotenv\`-before-imports pattern are unchanged).
- [ ] CI to run the full test suite + Trust Gates.
- [ ] Apply migration to remote (\`supabase db push --linked\`) before setting \`MANIFEST_SHADOW_PERCENT > 0\` in production. Local dev: \`supabase db reset --local\`.

## Rollout

Staged ramp recommended:
1. **Merge** with \`MANIFEST_SHADOW_PERCENT=0\` in production — zero behavior change, code lives quietly.
2. **Staging soak** at \`MANIFEST_SHADOW_PERCENT=10\` for 72 hours. Review \`agent_shadow_diffs\` rows by joining on \`divergence_kind <> 'identical'\` to spot routing/tool divergence.
3. **Production ramp** to \`MANIFEST_SHADOW_PERCENT=10\` if staging looks clean. If divergence is acceptable, consider flipping \`USE_MANIFESTS\` or retiring the legacy path entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)