### PR TITLE
feat(self-improvement): A/B eval harness + workflow scoring + policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ supabase db reset --local # rebuild local DB from migrations + seed
 - **Retry strategy** — 5 attempts, exponential backoff (2s initial, 2x multiplier, 60s max)
 - **Context caching** — Vertex AI context cache for token efficiency (configurable via `ENABLE_CONTEXT_CACHE`)
 - **Async throughout** — Full async Python with asyncpg, aioredis
+- **Self-improvement autonomy boundary** — what the engine may / must not auto-modify, the A/B eval harness invariants, and the rollback contract: see `docs/self-improvement-policy.md`. Treat as load-bearing when proposing changes to `app/services/self_improvement_engine.py` or `app/services/skill_experiment_evaluator.py`.
 
 ### Health Endpoints
 - `/health/live` — Liveness (no deps)

--- a/app/services/interaction_logger.py
+++ b/app/services/interaction_logger.py
@@ -14,7 +14,10 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from app.services.request_context import get_current_user_id
+from app.services.request_context import (
+    get_current_skill_resolution,
+    get_current_user_id,
+)
 from app.services.supabase import get_service_client
 from app.services.supabase_async import execute_async
 from supabase import Client
@@ -131,6 +134,18 @@ class InteractionLogger:
                 data["had_followup"] = had_followup
             if user_feedback is not None:
                 data["user_feedback"] = user_feedback
+
+            # Stamp A/B experiment attribution if the registry resolved a
+            # versioned skill for this turn.  All three fields stay NULL on
+            # system paths and on skills with no running experiment.
+            resolution = get_current_skill_resolution()
+            if resolution:
+                if resolution.get("skill_version_id"):
+                    data["skill_version_id"] = resolution["skill_version_id"]
+                if resolution.get("experiment_id"):
+                    data["experiment_id"] = resolution["experiment_id"]
+                if resolution.get("variant"):
+                    data["variant"] = resolution["variant"]
 
             response = await execute_async(
                 self._client.table(self._interactions_table).insert(data),

--- a/app/services/request_context.py
+++ b/app/services/request_context.py
@@ -24,6 +24,15 @@ _current_progress_queue: ContextVar[asyncio.Queue[dict[str, Any]] | None] = Cont
     "current_progress_queue", default=None
 )
 
+# Per-request skill resolution: which version was served, under which experiment,
+# in which variant.  Populated by the skills registry on use_skill(), consumed by
+# the interaction logger on insert.  Shape:
+#   {"skill_version_id": str | None, "experiment_id": str | None, "variant": str | None}
+# When unset (system paths, scheduled jobs), the logger writes NULL for all three.
+_current_skill_resolution: ContextVar[dict[str, str | None] | None] = ContextVar(
+    "current_skill_resolution", default=None
+)
+
 # Type alias for agent modes
 AgentMode = Literal["auto", "collab", "ask"]
 
@@ -82,6 +91,18 @@ def set_current_progress_queue(queue: asyncio.Queue[dict[str, Any]] | None) -> N
 def get_current_progress_queue() -> asyncio.Queue[dict[str, Any]] | None:
     """Get request-scoped progress queue."""
     return _current_progress_queue.get()
+
+
+def set_current_skill_resolution(
+    resolution: dict[str, str | None] | None,
+) -> None:
+    """Stash the skill version / experiment / variant served for this turn."""
+    _current_skill_resolution.set(resolution)
+
+
+def get_current_skill_resolution() -> dict[str, str | None] | None:
+    """Read the skill resolution for this turn (None when no skill was served)."""
+    return _current_skill_resolution.get()
 
 
 async def emit_progress_update(

--- a/app/services/scheduled_endpoints.py
+++ b/app/services/scheduled_endpoints.py
@@ -566,6 +566,7 @@ async def trigger_self_improvement_cycle(
 
     from app.services.self_improvement_engine import SelfImprovementEngine
     from app.services.self_improvement_settings import get_self_improvement_settings
+    from app.services.skill_experiment_evaluator import SkillExperimentEvaluator
 
     settings = await get_self_improvement_settings()
     engine = SelfImprovementEngine()
@@ -573,7 +574,23 @@ async def trigger_self_improvement_cycle(
         auto_execute=settings["auto_execute_enabled"],
         days=7,
     )
-    return {"success": True, "result": result}
+
+    # Second pass: decide the fate of any running A/B experiments using the
+    # interaction data collected during this cycle's window.  Independent of
+    # auto_execute — the evaluator only acts when the data crosses the
+    # statistical thresholds the experiment was created with.
+    try:
+        evaluator = SkillExperimentEvaluator()
+        experiment_summary = await evaluator.evaluate_running_experiments()
+    except Exception as exc:
+        logger.exception("Skill experiment evaluator failed")
+        experiment_summary = {"error": str(exc)}
+
+    return {
+        "success": True,
+        "result": result,
+        "experiments": experiment_summary,
+    }
 
 
 @router.get("/health")

--- a/app/services/scheduled_endpoints.py
+++ b/app/services/scheduled_endpoints.py
@@ -567,6 +567,7 @@ async def trigger_self_improvement_cycle(
     from app.services.self_improvement_engine import SelfImprovementEngine
     from app.services.self_improvement_settings import get_self_improvement_settings
     from app.services.skill_experiment_evaluator import SkillExperimentEvaluator
+    from app.services.workflow_template_scoring import evaluate_workflow_templates
 
     settings = await get_self_improvement_settings()
     engine = SelfImprovementEngine()
@@ -586,10 +587,20 @@ async def trigger_self_improvement_cycle(
         logger.exception("Skill experiment evaluator failed")
         experiment_summary = {"error": str(exc)}
 
+    # Third pass: roll up workflow template effectiveness over the same window
+    # so dashboards have parity with skill_scores.  Scoring only — no
+    # auto-modification of templates in Pillar 2.
+    try:
+        workflow_summary = await evaluate_workflow_templates(days=7)
+    except Exception as exc:
+        logger.exception("Workflow template scoring failed")
+        workflow_summary = {"error": str(exc)}
+
     return {
         "success": True,
         "result": result,
         "experiments": experiment_summary,
+        "workflow_templates": workflow_summary,
     }
 
 

--- a/app/services/self_improvement_engine.py
+++ b/app/services/self_improvement_engine.py
@@ -1149,24 +1149,88 @@ class SelfImprovementEngine:
             raise
 
     async def _execute_skill_refined(self, action: dict) -> dict[str, Any]:
-        """Refine an existing skill's knowledge using Gemini.
+        """Refine an existing skill's knowledge using Gemini and queue an A/B experiment.
 
-        Persists the new version to ``skill_versions`` with ``is_active=True``
-        while deactivating the previous active row, then updates the in-memory
-        registry.  DB failures are caught so the in-memory update still happens
-        as a best-effort fallback.
+        Instead of promoting the new version immediately, this:
+          1. Defers if a running experiment already exists for the skill.
+          2. Inserts the candidate version with ``is_active=False`` (control
+             stays active and continues serving the control bucket).
+          3. Creates a ``skill_experiments`` row in ``state='running'`` that
+             the SkillExperimentEvaluator picks up on the next cycle.
+          4. Updates the source ``improvement_actions`` row to
+             ``status='experimenting'`` so it's not re-queued.
+
+        The in-memory ``skills_registry._skills[name]`` is NOT mutated here —
+        per-user variant resolution is handled by ``registry.get_for_user``,
+        which reads ``skill_experiments`` directly.
         """
         skill_name = action.get("skill_name", "")
         skill = skills_registry.get(skill_name)
+        action_id = action.get("id")
 
         if not skill:
             return {
-                "action_id": action.get("id"),
+                "action_id": action_id,
                 "action_type": "skill_refined",
                 "detail": f"Skill '{skill_name}' not found in registry.",
             }
 
-        # Fetch recent negative interactions for context
+        # --- Deferral: only one live experiment per skill at a time. ---
+        try:
+            running_resp = await execute_async(
+                self.client.table("skill_experiments")
+                .select("id")
+                .eq("skill_name", skill_name)
+                .eq("state", "running")
+                .limit(1),
+                op_name="self_improvement.refined_check_running_experiment",
+            )
+            if running_resp.data:
+                running_id = running_resp.data[0]["id"]
+                if action_id:
+                    try:
+                        await execute_async(
+                            self.client.table("improvement_actions")
+                            .update(
+                                {
+                                    "status": "deferred",
+                                    "result_metadata": {
+                                        "defer_reason": "experiment_in_progress",
+                                        "running_experiment_id": running_id,
+                                    },
+                                }
+                            )
+                            .eq("id", action_id),
+                            op_name="self_improvement.refined_mark_deferred",
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to mark action %s deferred (non-fatal)",
+                            action_id,
+                            exc_info=True,
+                        )
+                return {
+                    "action_id": action_id,
+                    "action_type": "skill_refined",
+                    "skill_name": skill_name,
+                    "deferred": True,
+                    "running_experiment_id": running_id,
+                    "detail": (
+                        f"Skipped refinement of '{skill_name}': running experiment "
+                        f"{running_id} must conclude first."
+                    ),
+                }
+        except Exception:
+            # If we couldn't check, proceed — the unique partial index on
+            # skill_experiments(skill_name) WHERE state='running' will reject
+            # a duplicate create below.
+            logger.debug(
+                "deferral check failed for %s; relying on DB constraint",
+                skill_name,
+                exc_info=True,
+            )
+
+        # --- Generate the candidate knowledge with Gemini. ---
         neg_interactions = await self._fetch_negative_interactions(skill_name)
         negative_patterns = "\n".join(
             f"- {n.get('user_query', 'N/A')}: {n.get('feedback_comment', 'negative')}"
@@ -1189,15 +1253,12 @@ class SelfImprovementEngine:
         improved_knowledge = await self._generate_with_gemini(prompt)
         if not improved_knowledge:
             return {
-                "action_id": action.get("id"),
+                "action_id": action_id,
                 "action_type": "skill_refined",
                 "detail": "Gemini unavailable; skipped skill refinement.",
             }
 
-        # Store previous knowledge for potential revert
-        previous_knowledge = skill.knowledge
-
-        # Bump version
+        # Bump version string for human-readable display.
         old_version = skill.version or "1.0.0"
         parts = old_version.split(".")
         try:
@@ -1206,14 +1267,12 @@ class SelfImprovementEngine:
             parts = ["1", "0", "1"]
         new_version = ".".join(parts)
 
-        # --- Persist to skill_versions (DB write-through) ---
+        # --- Find current active version (becomes the experiment's control). ---
         previous_version_id: str | None = None
-        new_version_id: str | None = None
         try:
-            # 1. Find current active version for this skill
             active_resp = await execute_async(
                 self.client.table("skill_versions")
-                .select("id, previous_version_id")
+                .select("id")
                 .eq("skill_name", skill_name)
                 .eq("is_active", True)
                 .limit(1),
@@ -1221,16 +1280,38 @@ class SelfImprovementEngine:
             )
             if active_resp.data:
                 previous_version_id = active_resp.data[0]["id"]
+        except Exception:
+            logger.warning(
+                "Failed to fetch active version for '%s' — cannot start experiment",
+                skill_name,
+                exc_info=True,
+            )
+            return {
+                "action_id": action_id,
+                "action_type": "skill_refined",
+                "detail": (
+                    f"DB error fetching active version for '{skill_name}'; "
+                    "no experiment created."
+                ),
+            }
 
-                # 2. Deactivate the previous active version
-                await execute_async(
-                    self.client.table("skill_versions")
-                    .update({"is_active": False})
-                    .eq("id", previous_version_id),
-                    op_name="self_improvement.refined_deactivate",
-                )
+        if previous_version_id is None:
+            return {
+                "action_id": action_id,
+                "action_type": "skill_refined",
+                "detail": (
+                    f"No active skill_versions row for '{skill_name}'. "
+                    "A first version must exist before an A/B refinement can run."
+                ),
+            }
 
-            # 3. Insert the new version
+        effectiveness_before = action.get("metadata", {}).get(
+            "effectiveness_score"
+        ) or self._action_metadata(action).get("effectiveness_score")
+
+        # --- Insert the candidate version (is_active=False — control still serves). ---
+        new_version_id: str | None = None
+        try:
             insert_resp = await execute_async(
                 self.client.table("skill_versions").insert(
                     {
@@ -1238,45 +1319,120 @@ class SelfImprovementEngine:
                         "version": new_version,
                         "knowledge": improved_knowledge.strip(),
                         "previous_version_id": previous_version_id,
-                        "source_action_id": action.get("id"),
+                        "source_action_id": action_id,
                         "created_by": _SYSTEM_USER_ID,
-                        "is_active": True,
+                        "is_active": False,
                         "metadata": {
-                            "effectiveness_before": action.get("metadata", {}).get(
-                                "effectiveness_score"
-                            )
-                            or self._action_metadata(action).get(
-                                "effectiveness_score"
-                            ),
+                            "effectiveness_before": effectiveness_before,
+                            "candidate_for_experiment": True,
                         },
                     }
                 ),
-                op_name="self_improvement.refined_insert_version",
+                op_name="self_improvement.refined_insert_candidate",
             )
             if insert_resp.data:
                 new_version_id = insert_resp.data[0].get("id")
         except Exception:
             logger.warning(
-                "Failed to persist skill version for '%s'; "
-                "in-memory update will proceed as fallback",
+                "Failed to insert candidate version for '%s' — no experiment created",
                 skill_name,
                 exc_info=True,
             )
+            return {
+                "action_id": action_id,
+                "action_type": "skill_refined",
+                "detail": f"DB error inserting candidate version for '{skill_name}'.",
+            }
 
-        # --- Update in-memory registry ---
-        skill.knowledge = improved_knowledge.strip()
-        skill.version = new_version
-        skill.changelog = "Auto-refined by self-improvement engine"
+        if new_version_id is None:
+            return {
+                "action_id": action_id,
+                "action_type": "skill_refined",
+                "detail": (
+                    f"Candidate insert for '{skill_name}' returned no id; "
+                    "no experiment created."
+                ),
+            }
+
+        # --- Create the experiment row. ---
+        experiment_id: str | None = None
+        try:
+            exp_resp = await execute_async(
+                self.client.table("skill_experiments").insert(
+                    {
+                        "skill_name": skill_name,
+                        "control_version_id": previous_version_id,
+                        "candidate_version_id": new_version_id,
+                        "source_action_id": action_id,
+                        "state": "running",
+                        "metadata": {
+                            "candidate_display_version": new_version,
+                            "effectiveness_before": effectiveness_before,
+                        },
+                    }
+                ),
+                op_name="self_improvement.refined_create_experiment",
+            )
+            if exp_resp.data:
+                experiment_id = exp_resp.data[0].get("id")
+        except Exception:
+            # Likely the unique-running constraint fired due to a race.
+            # Leave the candidate version in place (it's harmless inactive)
+            # and bail with deferred status.
+            logger.warning(
+                "Failed to create experiment for '%s' (likely concurrent run)",
+                skill_name,
+                exc_info=True,
+            )
+            return {
+                "action_id": action_id,
+                "action_type": "skill_refined",
+                "skill_name": skill_name,
+                "candidate_version_id": new_version_id,
+                "detail": (
+                    f"Could not create experiment for '{skill_name}' — "
+                    "another run is likely already in progress."
+                ),
+            }
+
+        # --- Mark the source improvement_actions row as experimenting. ---
+        if action_id:
+            try:
+                await execute_async(
+                    self.client.table("improvement_actions")
+                    .update(
+                        {
+                            "status": "experimenting",
+                            "result_metadata": {
+                                "experiment_id": experiment_id,
+                                "candidate_version_id": new_version_id,
+                                "control_version_id": previous_version_id,
+                            },
+                        }
+                    )
+                    .eq("id", action_id),
+                    op_name="self_improvement.refined_mark_experimenting",
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to mark action %s experimenting (non-fatal)",
+                    action_id,
+                    exc_info=True,
+                )
 
         return {
-            "action_id": action.get("id"),
+            "action_id": action_id,
             "action_type": "skill_refined",
             "skill_name": skill_name,
-            "previous_knowledge_length": len(previous_knowledge or ""),
+            "experiment_id": experiment_id,
+            "control_version_id": previous_version_id,
+            "candidate_version_id": new_version_id,
             "new_knowledge_length": len(improved_knowledge),
-            "new_version": skill.version,
-            "new_version_id": new_version_id,
-            "detail": f"Refined skill '{skill_name}' to v{skill.version}",
+            "candidate_display_version": new_version,
+            "detail": (
+                f"Started A/B experiment {experiment_id} for '{skill_name}' "
+                f"(candidate v{new_version})"
+            ),
         }
 
     async def _execute_skill_demoted(self, action: dict) -> dict[str, Any]:

--- a/app/services/skill_experiment_evaluator.py
+++ b/app/services/skill_experiment_evaluator.py
@@ -1,0 +1,622 @@
+# Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+# Proprietary and confidential. See LICENSE file for details.
+
+"""Skill experiment evaluator — promotion/revert decisions for the A/B harness.
+
+Runs at the end of the scheduled self-improvement cycle.  For each
+``skill_experiments`` row in ``state='running'``:
+
+1. Aggregates ``interaction_logs`` grouped by ``variant`` ('control' vs 'treatment').
+2. Computes a per-interaction quality Bernoulli signal:
+       quality = (task_completed AND user_feedback != 'negative')
+                 OR (user_feedback = 'positive')
+3. Runs a two-proportion z-test on the quality rate.
+4. Decides:
+    - PROMOTE when z > +1.96 AND (p_treatment - p_control) >= min_effect_size
+    - REVERT when z < -1.96 (any significant regression — fast rollback on harm)
+    - INCONCLUSIVE-REVERT when sample budget or max_duration_days exhausted
+    - CONTINUE otherwise
+
+Promote flips ``is_active`` on the candidate ``skill_versions`` row, marks the
+experiment ``promoted``, writes an ``improvement_actions`` row with
+``action_type='skill_promoted', status='validated'``, calls
+``skills_registry.reload_skill_from_db()`` to refresh the in-memory skill, and
+emits a governance audit event.
+
+Revert and inconclusive-revert leave the control active and mark the candidate
+``metadata.reverted=true``.  No autonomous changes ever happen without a
+significant statistical signal in the data the evaluator just collected.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime, timezone
+from typing import Any
+
+from app.services.supabase import get_service_client
+from app.services.supabase_async import execute_async
+
+logger = logging.getLogger(__name__)
+
+# Mirrors _SYSTEM_USER_ID in self_improvement_engine.py — kept duplicated to
+# avoid an import cycle.  The governance audit writer silently swallows the
+# UUID parse failure that this non-UUID actor produces, matching the pattern
+# already used by the engine.
+_SYSTEM_USER_ID = "system:self-improvement-engine"
+
+# Decision thresholds.  These are fallbacks — every experiment row carries its
+# own min_samples_per_arm / max_samples_per_arm / max_duration_days / alpha /
+# min_effect_size and those take precedence.
+_DEFAULT_MIN_SAMPLES = 50
+_DEFAULT_MAX_SAMPLES = 500
+_DEFAULT_MAX_DURATION_DAYS = 14
+_DEFAULT_ALPHA = 0.05
+_DEFAULT_MIN_EFFECT_SIZE = 0.05
+
+# Two-sided z critical value at alpha=0.05.  Hard-coded because experiments
+# may set alpha but we never recompute the critical value without scipy.
+_Z_CRIT_TWO_SIDED_05 = 1.96
+
+
+class SkillExperimentEvaluator:
+    """Evaluator that decides the fate of running skill experiments.
+
+    Stateless apart from the Supabase client.  Safe to instantiate per call.
+    """
+
+    def __init__(self) -> None:
+        self.client = get_service_client()
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    async def evaluate_running_experiments(self) -> dict[str, Any]:
+        """Evaluate every running experiment and dispatch decisions.
+
+        Returns a summary dict suitable for inclusion in the cron response.
+        """
+        try:
+            resp = await execute_async(
+                self.client.table("skill_experiments")
+                .select(
+                    "id, skill_name, control_version_id, candidate_version_id, "
+                    "source_action_id, min_samples_per_arm, max_samples_per_arm, "
+                    "max_duration_days, alpha, min_effect_size, started_at, metadata"
+                )
+                .eq("state", "running"),
+                op_name="skill_experiment.fetch_running",
+            )
+            rows = resp.data or []
+        except Exception:
+            logger.exception("Failed to fetch running experiments")
+            return {
+                "experiments_evaluated": 0,
+                "promoted": 0,
+                "reverted": 0,
+                "inconclusive": 0,
+                "still_running": 0,
+                "errors": 1,
+            }
+
+        promoted = 0
+        reverted = 0
+        inconclusive = 0
+        still_running = 0
+        decisions: list[dict[str, Any]] = []
+
+        for exp in rows:
+            try:
+                decision = await self._evaluate_one(exp)
+                decisions.append(decision)
+                outcome = decision.get("outcome")
+                if outcome == "promoted":
+                    promoted += 1
+                elif outcome == "reverted":
+                    reverted += 1
+                elif outcome == "inconclusive_reverted":
+                    inconclusive += 1
+                else:
+                    still_running += 1
+            except Exception:
+                logger.exception(
+                    "Failed evaluating experiment %s — leaving running",
+                    exp.get("id"),
+                )
+                still_running += 1
+
+        return {
+            "experiments_evaluated": len(rows),
+            "promoted": promoted,
+            "reverted": reverted,
+            "inconclusive": inconclusive,
+            "still_running": still_running,
+            "decisions": decisions,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        }
+
+    # ------------------------------------------------------------------
+    # Single experiment
+    # ------------------------------------------------------------------
+
+    async def _evaluate_one(self, exp: dict[str, Any]) -> dict[str, Any]:
+        """Decide on a single running experiment."""
+        exp_id = exp["id"]
+        skill_name = exp["skill_name"]
+        min_samples = int(exp.get("min_samples_per_arm") or _DEFAULT_MIN_SAMPLES)
+        max_samples = int(exp.get("max_samples_per_arm") or _DEFAULT_MAX_SAMPLES)
+        max_duration_days = int(
+            exp.get("max_duration_days") or _DEFAULT_MAX_DURATION_DAYS
+        )
+        min_effect_size = float(
+            exp.get("min_effect_size") or _DEFAULT_MIN_EFFECT_SIZE
+        )
+
+        # Collect per-arm aggregates.
+        agg = await self._aggregate_arms(exp_id)
+        n_c, q_c = agg["control"]
+        n_t, q_t = agg["treatment"]
+
+        decision_base = {
+            "experiment_id": exp_id,
+            "skill_name": skill_name,
+            "n_control": n_c,
+            "n_treatment": n_t,
+            "p_control": _safe_rate(q_c, n_c),
+            "p_treatment": _safe_rate(q_t, n_t),
+        }
+
+        # Deadline check (independent of sample count).
+        duration_expired = _duration_expired(exp.get("started_at"), max_duration_days)
+
+        # Continue if either arm hasn't reached the minimum sample size and
+        # the deadline hasn't passed.
+        if (n_c < min_samples or n_t < min_samples) and not duration_expired:
+            decision_base["outcome"] = "running"
+            decision_base["decision_reason"] = "below_min_samples"
+            return decision_base
+
+        # Stat test: two-proportion z-test on the quality rate.
+        z = _two_proportion_z(q_c, n_c, q_t, n_t)
+        decision_base["z"] = z
+
+        if z is None:
+            # Both arms empty or pooled p == 0: cannot test.  Treat as inconclusive
+            # if duration expired, else keep waiting.
+            if duration_expired:
+                decision_base["decision_reason"] = "inconclusive_no_signal"
+                return await self._apply_revert(exp, decision_base, inconclusive=True)
+            decision_base["outcome"] = "running"
+            decision_base["decision_reason"] = "no_signal_yet"
+            return decision_base
+
+        p_diff = decision_base["p_treatment"] - decision_base["p_control"]
+        decision_base["p_diff"] = p_diff
+
+        # Significant regression — revert regardless of effect size.
+        if z < -_Z_CRIT_TWO_SIDED_05:
+            decision_base["decision_reason"] = "significant_regression"
+            return await self._apply_revert(exp, decision_base, inconclusive=False)
+
+        # Significant lift AND meaningful effect size — promote.
+        if z > _Z_CRIT_TWO_SIDED_05 and p_diff >= min_effect_size:
+            decision_base["decision_reason"] = "significant_lift"
+            return await self._apply_promote(exp, decision_base)
+
+        # Sample budget exhausted or duration expired without a verdict —
+        # inconclusive revert (do-no-harm bias).
+        if (n_c >= max_samples and n_t >= max_samples) or duration_expired:
+            decision_base["decision_reason"] = (
+                "inconclusive_max_samples" if not duration_expired else "inconclusive_low_traffic"
+            )
+            return await self._apply_revert(exp, decision_base, inconclusive=True)
+
+        # Otherwise, keep collecting.
+        decision_base["outcome"] = "running"
+        decision_base["decision_reason"] = "no_decision_yet"
+        return decision_base
+
+    # ------------------------------------------------------------------
+    # Aggregation
+    # ------------------------------------------------------------------
+
+    async def _aggregate_arms(self, exp_id: str) -> dict[str, tuple[int, int]]:
+        """Return per-arm (n, quality) over the experiment's lifetime."""
+        try:
+            resp = await execute_async(
+                self.client.table("interaction_logs")
+                .select("variant, task_completed, user_feedback")
+                .eq("experiment_id", exp_id)
+                .not_.is_("variant", "null"),
+                op_name="skill_experiment.aggregate_arms",
+            )
+            rows = resp.data or []
+        except Exception:
+            logger.warning(
+                "Failed to aggregate interactions for experiment %s",
+                exp_id,
+                exc_info=True,
+            )
+            return {"control": (0, 0), "treatment": (0, 0)}
+
+        n_c = n_t = 0
+        q_c = q_t = 0
+        for r in rows:
+            variant = r.get("variant")
+            quality = _interaction_quality(
+                r.get("task_completed"), r.get("user_feedback")
+            )
+            if variant == "control":
+                n_c += 1
+                q_c += quality
+            elif variant == "treatment":
+                n_t += 1
+                q_t += quality
+        return {"control": (n_c, q_c), "treatment": (n_t, q_t)}
+
+    # ------------------------------------------------------------------
+    # Decisions
+    # ------------------------------------------------------------------
+
+    async def _apply_promote(
+        self, exp: dict[str, Any], decision: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Flip is_active to the candidate; mark experiment promoted; audit."""
+        exp_id = exp["id"]
+        skill_name = exp["skill_name"]
+        control_id = exp["control_version_id"]
+        candidate_id = exp["candidate_version_id"]
+        p_control = decision["p_control"]
+        p_treatment = decision["p_treatment"]
+
+        # Atomicity: do candidate-active first (constraint allows brief overlap
+        # because is_active=true on both would violate the unique partial
+        # index — so we must deactivate the control before activating the
+        # candidate).  If the deactivate succeeds but the activate fails the
+        # skill is left with NO active version, which the registry handles
+        # gracefully (falls back to None and the skill is treated as missing).
+        try:
+            await execute_async(
+                self.client.table("skill_versions")
+                .update({"is_active": False})
+                .eq("id", control_id),
+                op_name="skill_experiment.promote_deactivate_control",
+            )
+            await execute_async(
+                self.client.table("skill_versions")
+                .update({"is_active": True})
+                .eq("id", candidate_id),
+                op_name="skill_experiment.promote_activate_candidate",
+            )
+        except Exception:
+            logger.exception(
+                "Failed flipping is_active for experiment %s — leaving running",
+                exp_id,
+            )
+            decision["outcome"] = "running"
+            decision["decision_reason"] = "promote_db_error"
+            return decision
+
+        # Mark the experiment promoted.
+        now_iso = datetime.now(tz=timezone.utc).isoformat()
+        try:
+            await execute_async(
+                self.client.table("skill_experiments")
+                .update(
+                    {
+                        "state": "promoted",
+                        "decided_at": now_iso,
+                        "decision_reason": decision["decision_reason"],
+                    }
+                )
+                .eq("id", exp_id),
+                op_name="skill_experiment.promote_mark_state",
+            )
+        except Exception:
+            logger.warning(
+                "Failed marking experiment %s promoted (DB roll-forward inconsistent)",
+                exp_id,
+                exc_info=True,
+            )
+
+        # Insert a skill_promoted action with before/after.
+        try:
+            await execute_async(
+                self.client.table("improvement_actions").insert(
+                    {
+                        "action_type": "skill_promoted",
+                        "skill_name": skill_name,
+                        "trigger_reason": (
+                            f"A/B experiment {exp_id} significant lift "
+                            f"(p_c={p_control:.3f}, p_t={p_treatment:.3f}, "
+                            f"z={decision['z']:.2f})"
+                        ),
+                        "status": "validated",
+                        "effectiveness_before": p_control,
+                        "effectiveness_after": p_treatment,
+                        "details": {
+                            "experiment_id": exp_id,
+                            "control_version_id": control_id,
+                            "candidate_version_id": candidate_id,
+                            "n_control": decision["n_control"],
+                            "n_treatment": decision["n_treatment"],
+                        },
+                    }
+                ),
+                op_name="skill_experiment.promote_insert_action",
+            )
+        except Exception:
+            logger.warning(
+                "Failed inserting skill_promoted action for experiment %s",
+                exp_id,
+                exc_info=True,
+            )
+
+        # Mark the originating action validated.
+        source_action_id = exp.get("source_action_id")
+        if source_action_id:
+            try:
+                await execute_async(
+                    self.client.table("improvement_actions")
+                    .update(
+                        {
+                            "status": "validated",
+                            "effectiveness_after": p_treatment,
+                        }
+                    )
+                    .eq("id", source_action_id),
+                    op_name="skill_experiment.promote_close_source_action",
+                )
+            except Exception:
+                logger.warning(
+                    "Failed closing source action %s for experiment %s",
+                    source_action_id,
+                    exp_id,
+                    exc_info=True,
+                )
+
+        # Refresh the in-memory skill so subsequent requests serve the new
+        # active version's knowledge.  Lazy import to avoid loading the
+        # registry at module-import time.
+        try:
+            from app.skills.registry import skills_registry
+
+            skills_registry.reload_skill_from_db(skill_name)
+        except Exception:
+            logger.warning(
+                "reload_skill_from_db failed after promote for %s",
+                skill_name,
+                exc_info=True,
+            )
+
+        await self._audit(
+            action_type="self_improvement.experiment_promoted",
+            resource_id=exp_id,
+            details={
+                "skill_name": skill_name,
+                "candidate_version_id": candidate_id,
+                "control_version_id": control_id,
+                **{k: v for k, v in decision.items() if k != "outcome"},
+            },
+        )
+
+        decision["outcome"] = "promoted"
+        return decision
+
+    async def _apply_revert(
+        self,
+        exp: dict[str, Any],
+        decision: dict[str, Any],
+        *,
+        inconclusive: bool,
+    ) -> dict[str, Any]:
+        """Mark experiment reverted; flag candidate row; audit."""
+        exp_id = exp["id"]
+        skill_name = exp["skill_name"]
+        candidate_id = exp["candidate_version_id"]
+
+        now_iso = datetime.now(tz=timezone.utc).isoformat()
+        state_label = "reverted"  # Same state for both — distinguished by reason.
+
+        try:
+            await execute_async(
+                self.client.table("skill_experiments")
+                .update(
+                    {
+                        "state": state_label,
+                        "decided_at": now_iso,
+                        "decision_reason": decision["decision_reason"],
+                    }
+                )
+                .eq("id", exp_id),
+                op_name="skill_experiment.revert_mark_state",
+            )
+        except Exception:
+            logger.warning(
+                "Failed marking experiment %s reverted",
+                exp_id,
+                exc_info=True,
+            )
+
+        # Flag the candidate skill_versions row.  We don't change is_active —
+        # it's already false (control was untouched).  This metadata flag
+        # exists so dashboards can distinguish reverted candidates from
+        # historical inactive versions.
+        try:
+            await execute_async(
+                self.client.table("skill_versions")
+                .update(
+                    {
+                        "metadata": {
+                            "reverted": True,
+                            "reverted_at": now_iso,
+                            "reverted_reason": decision["decision_reason"],
+                            "experiment_id": exp_id,
+                        }
+                    }
+                )
+                .eq("id", candidate_id),
+                op_name="skill_experiment.revert_flag_candidate",
+            )
+        except Exception:
+            logger.warning(
+                "Failed flagging candidate version %s as reverted",
+                candidate_id,
+                exc_info=True,
+            )
+
+        # Close out the originating improvement_actions row.
+        source_action_id = exp.get("source_action_id")
+        if source_action_id:
+            try:
+                await execute_async(
+                    self.client.table("improvement_actions")
+                    .update(
+                        {
+                            "status": "reverted",
+                            "effectiveness_after": decision.get("p_treatment"),
+                            "result_metadata": {
+                                "experiment_id": exp_id,
+                                "decision_reason": decision["decision_reason"],
+                                "inconclusive": inconclusive,
+                            },
+                        }
+                    )
+                    .eq("id", source_action_id),
+                    op_name="skill_experiment.revert_close_source_action",
+                )
+            except Exception:
+                logger.warning(
+                    "Failed closing source action %s after revert",
+                    source_action_id,
+                    exc_info=True,
+                )
+
+        # Drop the in-memory experiment cache so the next call resolves to
+        # active (control) without waiting for TTL.
+        try:
+            from app.skills.registry import skills_registry
+
+            skills_registry._invalidate_experiment(skill_name)
+        except Exception:
+            logger.debug(
+                "registry invalidation skipped for %s",
+                skill_name,
+                exc_info=True,
+            )
+
+        await self._audit(
+            action_type=(
+                "self_improvement.experiment_inconclusive_reverted"
+                if inconclusive
+                else "self_improvement.experiment_reverted"
+            ),
+            resource_id=exp_id,
+            details={
+                "skill_name": skill_name,
+                "candidate_version_id": candidate_id,
+                **{k: v for k, v in decision.items() if k != "outcome"},
+            },
+        )
+
+        decision["outcome"] = (
+            "inconclusive_reverted" if inconclusive else "reverted"
+        )
+        return decision
+
+    # ------------------------------------------------------------------
+    # Audit helper
+    # ------------------------------------------------------------------
+
+    async def _audit(
+        self, *, action_type: str, resource_id: str, details: dict[str, Any]
+    ) -> None:
+        """Fire-and-forget governance audit write."""
+        try:
+            from app.services.governance_service import get_governance_service
+
+            gov = get_governance_service()
+            await gov.log_event(
+                user_id=_SYSTEM_USER_ID,
+                action_type=action_type,
+                resource_type="skill_experiment",
+                resource_id=resource_id,
+                details=details,
+            )
+        except Exception:
+            logger.debug(
+                "audit write failed for %s (non-fatal)",
+                action_type,
+                exc_info=True,
+            )
+
+
+# =====================================================================
+# Pure helpers (exposed for unit testing)
+# =====================================================================
+
+
+def _interaction_quality(task_completed: Any, user_feedback: Any) -> int:
+    """Map a row to a 0/1 quality outcome.
+
+    quality = 1 iff:
+        (task_completed AND user_feedback != 'negative')
+        OR user_feedback == 'positive'
+    """
+    fb = user_feedback if isinstance(user_feedback, str) else None
+    if fb == "positive":
+        return 1
+    if task_completed is True and fb != "negative":
+        return 1
+    return 0
+
+
+def _safe_rate(numerator: int, denominator: int) -> float:
+    """Defensive division — returns 0.0 when denominator is 0."""
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator
+
+
+def _two_proportion_z(
+    q_c: int, n_c: int, q_t: int, n_t: int
+) -> float | None:
+    """Compute the two-proportion z statistic.
+
+    Returns None when the test cannot be performed (empty arm or zero
+    pooled variance).  Sign convention: positive z means treatment > control.
+    """
+    if n_c <= 0 or n_t <= 0:
+        return None
+    p_c = q_c / n_c
+    p_t = q_t / n_t
+    pooled = (q_c + q_t) / (n_c + n_t)
+    if pooled <= 0 or pooled >= 1:
+        # No variance — every outcome is identical.
+        return None
+    se = math.sqrt(pooled * (1 - pooled) * (1 / n_c + 1 / n_t))
+    if se == 0:
+        return None
+    return (p_t - p_c) / se
+
+
+def _duration_expired(started_at: Any, max_duration_days: int) -> bool:
+    """Whether the experiment started more than max_duration_days ago."""
+    if not started_at:
+        return False
+    try:
+        if isinstance(started_at, str):
+            # Supabase returns ISO with optional 'Z' or '+00:00'.
+            normalised = started_at.replace("Z", "+00:00")
+            started = datetime.fromisoformat(normalised)
+        else:
+            started = started_at
+    except (TypeError, ValueError):
+        return False
+    now = datetime.now(tz=timezone.utc)
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    elapsed = (now - started).total_seconds()
+    return elapsed >= max_duration_days * 86400

--- a/app/services/workflow_template_scoring.py
+++ b/app/services/workflow_template_scoring.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+# Proprietary and confidential. See LICENSE file for details.
+
+"""Workflow template effectiveness scoring — Pillar 2 of the eval harness.
+
+Mirrors ``app/services/self_improvement_engine.py`` for workflow templates:
+rolls up ``workflow_executions`` + ``workflow_steps`` telemetry over a window
+into a per-version effectiveness score, computes a delta against the previous
+window, and persists to ``workflow_template_scores``.
+
+Weights (sum to 1.0):
+    completion_rate     0.50  — primary success signal
+    1 - error_rate      0.20  — explicit failures penalised
+    1 - retry_rate      0.15  — steps re-attempted (attempt_count > 1)
+    1 - escalation_rate 0.15  — SLA escalations
+
+These weights intentionally differ from the skill formula in
+``self_improvement_engine.py``: workflows have no user-feedback proxy in v1
+(no thumbs-up surface yet), so the weight on "positive_rate" is absent and
+re-distributed across completion + the negative-signal complements.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.services.supabase import get_service_client
+from app.services.supabase_async import execute_async
+
+logger = logging.getLogger(__name__)
+
+# Composite weights (must sum to 1.0).
+_W_COMPLETION = 0.50
+_W_ERROR = 0.20
+_W_RETRY = 0.15
+_W_ESCALATION = 0.15
+
+# Trend thresholds (mirror SelfImprovementEngine).
+_TREND_EPSILON = 0.02
+
+
+async def evaluate_workflow_templates(days: int = 7) -> dict[str, Any]:
+    """Score every workflow template version over the last *days* days.
+
+    Returns a summary suitable for inclusion in the scheduled-cron response.
+    """
+    client = get_service_client()
+    now = datetime.now(tz=timezone.utc)
+    period_start_dt = now - timedelta(days=days)
+    period_start = period_start_dt.isoformat()
+    period_end = now.isoformat()
+    evaluation_period = f"{now.strftime('%Y-%m-%d')}_daily"
+
+    try:
+        exec_resp = await execute_async(
+            client.table("workflow_executions")
+            .select(
+                "id, user_id, template_id, template_version_id, status, started_at"
+            )
+            .gte("started_at", period_start)
+            .lte("started_at", period_end),
+            op_name="workflow_template_scoring.fetch_executions",
+        )
+        executions = exec_resp.data or []
+    except Exception:
+        logger.exception("Failed fetching workflow_executions for scoring")
+        return {
+            "scored": 0,
+            "errors": 1,
+            "evaluation_period": evaluation_period,
+        }
+
+    if not executions:
+        return {
+            "scored": 0,
+            "evaluation_period": evaluation_period,
+            "detail": "no_executions_in_window",
+        }
+
+    # Fetch step telemetry for the in-window executions.
+    execution_ids = [e["id"] for e in executions if e.get("id")]
+    step_rows: list[dict[str, Any]] = []
+    if execution_ids:
+        try:
+            step_resp = await execute_async(
+                client.table("workflow_steps")
+                .select("execution_id, attempt_count, sla_status")
+                .in_("execution_id", execution_ids),
+                op_name="workflow_template_scoring.fetch_steps",
+            )
+            step_rows = step_resp.data or []
+        except Exception:
+            logger.warning(
+                "Failed fetching workflow_steps for scoring — retry/escalation "
+                "rates will be 0 for this run",
+                exc_info=True,
+            )
+
+    # Pre-index steps by execution to compute per-run retry / escalation.
+    steps_by_exec: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for s in step_rows:
+        exec_id = s.get("execution_id")
+        if exec_id:
+            steps_by_exec[exec_id].append(s)
+
+    # Group executions by (template_id, template_version_id).
+    groups: dict[tuple[str, str | None], list[dict[str, Any]]] = defaultdict(list)
+    for e in executions:
+        tpl_id = e.get("template_id")
+        ver_id = e.get("template_version_id")  # may be None for legacy runs
+        if not tpl_id:
+            continue
+        groups[(tpl_id, ver_id)].append(e)
+
+    scored_count = 0
+    error_count = 0
+
+    for (template_id, template_version_id), runs in groups.items():
+        try:
+            metrics = _compute_metrics(runs, steps_by_exec)
+            effectiveness = _composite(metrics)
+
+            # Trend vs previous row for same (template_id, version).
+            previous = await _fetch_previous_score(
+                client, template_id, template_version_id
+            )
+            score_delta, trend = _trend(effectiveness, previous)
+
+            record = {
+                "template_id": template_id,
+                "template_version_id": template_version_id,
+                "evaluation_period": evaluation_period,
+                "period_start": period_start,
+                "period_end": period_end,
+                "total_runs": metrics["total"],
+                "unique_users": metrics["unique_users"],
+                "completion_rate": round(metrics["completion_rate"], 4),
+                "error_rate": round(metrics["error_rate"], 4),
+                "retry_rate": round(metrics["retry_rate"], 4),
+                "escalation_rate": round(metrics["escalation_rate"], 4),
+                "effectiveness_score": round(effectiveness, 4),
+                "score_delta": score_delta,
+                "trend": trend,
+                "evaluated_at": now.isoformat(),
+                "metadata": {
+                    "period_start": period_start,
+                    "period_end": period_end,
+                    "days": days,
+                },
+            }
+
+            await execute_async(
+                client.table("workflow_template_scores").upsert(
+                    record,
+                    on_conflict="template_id,template_version_id,evaluation_period",
+                ),
+                op_name="workflow_template_scoring.upsert_score",
+            )
+            scored_count += 1
+        except Exception:
+            logger.exception(
+                "Failed scoring template %s version %s",
+                template_id,
+                template_version_id,
+            )
+            error_count += 1
+
+    logger.info(
+        "workflow_template_scoring scored=%d errors=%d period=%s",
+        scored_count,
+        error_count,
+        evaluation_period,
+    )
+    return {
+        "scored": scored_count,
+        "errors": error_count,
+        "evaluation_period": evaluation_period,
+        "groups_evaluated": len(groups),
+    }
+
+
+# =====================================================================
+# Pure helpers (exposed for unit testing)
+# =====================================================================
+
+
+def _compute_metrics(
+    runs: list[dict[str, Any]],
+    steps_by_exec: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Aggregate raw run + step rows into rate metrics.
+
+    Edge cases:
+      - A run with no step rows contributes 0 to retry and escalation
+        numerators (we cannot conclude it had retries or escalations).
+      - 'completed' status counts toward completion; 'failed' counts toward
+        errors.  Other statuses (running, cancelled, etc.) count toward
+        total but not toward completion or error.
+    """
+    total = len(runs)
+    completed = 0
+    failed = 0
+    retried = 0
+    escalated = 0
+    unique_users: set[str] = set()
+
+    for r in runs:
+        if r.get("user_id"):
+            unique_users.add(r["user_id"])
+        status = r.get("status")
+        if status == "completed":
+            completed += 1
+        elif status == "failed":
+            failed += 1
+        steps = steps_by_exec.get(r.get("id"), [])
+        if any((s.get("attempt_count") or 0) > 1 for s in steps):
+            retried += 1
+        if any(s.get("sla_status") == "escalated" for s in steps):
+            escalated += 1
+
+    return {
+        "total": total,
+        "unique_users": len(unique_users),
+        "completion_rate": completed / total if total else 0.0,
+        "error_rate": failed / total if total else 0.0,
+        "retry_rate": retried / total if total else 0.0,
+        "escalation_rate": escalated / total if total else 0.0,
+    }
+
+
+def _composite(metrics: dict[str, float]) -> float:
+    """Weighted composite — see module docstring for weight rationale."""
+    return (
+        _W_COMPLETION * metrics["completion_rate"]
+        + _W_ERROR * (1.0 - metrics["error_rate"])
+        + _W_RETRY * (1.0 - metrics["retry_rate"])
+        + _W_ESCALATION * (1.0 - metrics["escalation_rate"])
+    )
+
+
+async def _fetch_previous_score(
+    client: Any, template_id: str, template_version_id: str | None
+) -> float | None:
+    """Return the previous evaluated_at row's effectiveness_score, or None."""
+    try:
+        query = (
+            client.table("workflow_template_scores")
+            .select("effectiveness_score")
+            .eq("template_id", template_id)
+            .order("evaluated_at", desc=True)
+            .limit(1)
+        )
+        if template_version_id is None:
+            query = query.is_("template_version_id", "null")
+        else:
+            query = query.eq("template_version_id", template_version_id)
+        resp = await execute_async(
+            query, op_name="workflow_template_scoring.fetch_previous"
+        )
+        rows = resp.data or []
+        if rows:
+            return float(rows[0].get("effectiveness_score") or 0.0)
+    except Exception:
+        logger.debug(
+            "previous score lookup failed for template %s",
+            template_id,
+            exc_info=True,
+        )
+    return None
+
+
+def _trend(
+    effectiveness: float, previous: float | None
+) -> tuple[float | None, str]:
+    """Compute score_delta + categorical trend label."""
+    if previous is None:
+        return None, "new"
+    delta = round(effectiveness - previous, 4)
+    if delta > _TREND_EPSILON:
+        return delta, "improving"
+    if delta < -_TREND_EPSILON:
+        return delta, "declining"
+    return delta, "stable"

--- a/app/skills/registry.py
+++ b/app/skills/registry.py
@@ -18,14 +18,36 @@ This module defines the Skill model and SkillsRegistry class that provides
 a centralized way for agents to access domain-specific knowledge and tools.
 """
 
+import hashlib
 import logging
+import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
+
+# Per-skill experiment cache TTL.  Short enough that a promote/revert decision
+# made by the evaluator becomes visible quickly without restart; long enough
+# that the hot path is not constantly hitting Supabase.
+_EXPERIMENT_CACHE_TTL_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class SkillResolution:
+    """Result of resolving a skill for a specific user.
+
+    Returned by SkillsRegistry.get_for_user().  The interaction logger reads
+    these fields back from request_context to stamp interaction_logs rows.
+    """
+
+    skill: "Skill | None"
+    skill_version_id: str | None  # active or experiment-arm version, when known
+    experiment_id: str | None     # populated only when a running experiment was joined
+    variant: str | None           # 'control' | 'treatment' | None when no experiment
 
 
 class AgentID(str, Enum):
@@ -146,6 +168,12 @@ class SkillsRegistry:
             # Custom skills should be loaded explicitly or lazily
             self._custom_skills_loaded = False
 
+            # Per-skill A/B experiment cache.  Key = skill_name.
+            # Value = (cached_entry, expires_at_monotonic).
+            # cached_entry is a dict with keys: experiment_id, control_skill,
+            # candidate_skill, or None to negatively cache "no experiment".
+            self._experiment_cache: dict[str, tuple[dict | None, float]] = {}
+
     def _ensure_custom_skills_loaded(self) -> None:
         """Lazily load custom skills to avoid circular imports."""
         if not getattr(self, "_custom_skills_loaded", False):
@@ -161,6 +189,192 @@ class SkillsRegistry:
                 pass
             except Exception as e:
                 logger.warning("Error loading custom skills: %s", e)
+
+    def _fetch_running_experiment(self, name: str) -> dict | None:
+        """Fetch the running experiment for *name* from Supabase, if any.
+
+        Returns a dict with experiment_id, control_skill, candidate_skill,
+        or None when no experiment is running.  Always swallows errors and
+        returns None on failure — the caller must fall back to active version.
+        """
+        try:
+            # Lazy import: avoid pulling Supabase into module-load chain.
+            from app.services.supabase import get_service_client
+
+            client = get_service_client()
+            exp_resp = (
+                client.table("skill_experiments")
+                .select(
+                    "id, control_version_id, candidate_version_id, "
+                    "control:skill_versions!skill_experiments_control_version_id_fkey(id, knowledge), "
+                    "candidate:skill_versions!skill_experiments_candidate_version_id_fkey(id, knowledge)"
+                )
+                .eq("skill_name", name)
+                .eq("state", "running")
+                .limit(1)
+                .execute()
+            )
+        except Exception as e:
+            logger.debug("experiment fetch failed for %s: %s", name, e)
+            return None
+
+        rows = getattr(exp_resp, "data", None) or []
+        if not rows:
+            return None
+
+        row = rows[0]
+        control_row = row.get("control") or {}
+        candidate_row = row.get("candidate") or {}
+        if not control_row or not candidate_row:
+            return None
+
+        base = self._skills.get(name)
+        if base is None:
+            # We must overlay onto an in-memory base to keep description/category
+            # consistent.  If the base disappeared, fall through to active.
+            return None
+
+        return {
+            "experiment_id": row["id"],
+            "_control_version_id": control_row["id"],
+            "_candidate_version_id": candidate_row["id"],
+            "control_skill": self._skill_with_knowledge(
+                base, control_row["id"], control_row.get("knowledge")
+            ),
+            "candidate_skill": self._skill_with_knowledge(
+                base, candidate_row["id"], candidate_row.get("knowledge")
+            ),
+        }
+
+    @staticmethod
+    def _skill_with_knowledge(
+        base: "Skill", version_id: str, knowledge: str | None
+    ) -> "Skill":
+        """Copy *base* with the version's knowledge content substituted in.
+
+        The version_id is tracked separately via SkillResolution rather than
+        being stored on the Skill model itself.
+        """
+        del version_id  # carried alongside in the cache entry / SkillResolution
+        return base.model_copy(update={"knowledge": knowledge})
+
+    def _get_cached_experiment(self, name: str) -> dict | None:
+        """Return cached experiment entry for *name*, refreshing on TTL miss.
+
+        Negative results are also cached so we don't hammer Supabase for
+        skills that have no running experiment (the common case).
+        """
+        now = time.monotonic()
+        cached = self._experiment_cache.get(name)
+        if cached is not None and cached[1] > now:
+            return cached[0]
+
+        fresh = self._fetch_running_experiment(name)
+        self._experiment_cache[name] = (fresh, now + _EXPERIMENT_CACHE_TTL_SECONDS)
+        return fresh
+
+    def _invalidate_experiment(self, name: str) -> None:
+        """Drop the cached experiment entry for *name*.
+
+        Called by the evaluator on promote/revert so the next request sees
+        the updated state without waiting for TTL.
+        """
+        self._experiment_cache.pop(name, None)
+
+    @staticmethod
+    def _bucket(user_id: str, experiment_id: str) -> str:
+        """Per-user sticky variant assignment.
+
+        SHA-256 hash of user_id + experiment_id, mod 2.  Same user always
+        sees the same variant for a given experiment.  Treat as a stable
+        feature flag — never re-randomize mid-experiment.
+        """
+        key = f"{user_id}:{experiment_id}".encode()
+        h = int(hashlib.sha256(key).hexdigest(), 16)
+        return "control" if h % 2 == 0 else "treatment"
+
+    def get_for_user(self, name: str, user_id: str | None) -> "SkillResolution":
+        """Resolve a skill for a specific user, honoring any running experiment.
+
+        Falls back to the active in-memory skill (no version stamping) when:
+          - user_id is None (system jobs, schedulers, anonymous paths)
+          - no experiment is running for this skill
+          - any DB error or cache miss the fetcher couldn't resolve
+
+        The returned SkillResolution is the canonical place callers should
+        stash into request_context for downstream logging.
+        """
+        self._ensure_custom_skills_loaded()
+        base = self._skills.get(name)
+        if base is None:
+            return SkillResolution(
+                skill=None, skill_version_id=None, experiment_id=None, variant=None
+            )
+
+        if user_id is None:
+            return SkillResolution(
+                skill=base, skill_version_id=None, experiment_id=None, variant=None
+            )
+
+        entry = self._get_cached_experiment(name)
+        if entry is None:
+            return SkillResolution(
+                skill=base, skill_version_id=None, experiment_id=None, variant=None
+            )
+
+        variant = self._bucket(user_id, entry["experiment_id"])
+        if variant == "control":
+            chosen_skill = entry["control_skill"]
+            # Re-fetch the version_id from the raw entry (carried alongside).
+            # The cache stores _skill_with_knowledge output without the id;
+            # we re-derive it from the cached row via a parallel structure.
+            version_id = entry.get("_control_version_id")
+        else:
+            chosen_skill = entry["candidate_skill"]
+            version_id = entry.get("_candidate_version_id")
+
+        return SkillResolution(
+            skill=chosen_skill,
+            skill_version_id=version_id,
+            experiment_id=entry["experiment_id"],
+            variant=variant,
+        )
+
+    def reload_skill_from_db(self, name: str) -> bool:
+        """Re-read the active version's knowledge from skill_versions into memory.
+
+        Called by the evaluator after promote so the in-memory `_skills[name]`
+        carries the promoted candidate's knowledge.  Returns True on success.
+        """
+        try:
+            from app.services.supabase import get_service_client
+
+            client = get_service_client()
+            resp = (
+                client.table("skill_versions")
+                .select("id, knowledge")
+                .eq("skill_name", name)
+                .eq("is_active", True)
+                .limit(1)
+                .execute()
+            )
+        except Exception as e:
+            logger.warning("reload_skill_from_db failed for %s: %s", name, e)
+            return False
+
+        rows = getattr(resp, "data", None) or []
+        if not rows:
+            return False
+
+        active = rows[0]
+        existing = self._skills.get(name)
+        if existing is None:
+            return False
+        self._skills[name] = existing.model_copy(
+            update={"knowledge": active.get("knowledge")}
+        )
+        self._invalidate_experiment(name)
+        return True
 
     def register(self, skill: Skill) -> None:
         """Register a skill in the registry."""
@@ -283,6 +497,10 @@ class SkillsRegistry:
     ) -> dict[str, Any]:
         """Use a skill - returns knowledge or executes function.
 
+        Resolves the per-user variant when a skill_experiments row is running
+        for this skill, then stashes the resolution into request_context so
+        the interaction logger can stamp the eventual row.
+
         Args:
             name: The skill name to use.
             agent_id: The ID of the agent attempting to use the skill.
@@ -293,13 +511,23 @@ class SkillsRegistry:
             Dictionary with skill output or knowledge.
             Returns error if agent lacks permission.
         """
-        import time
-
         start_time = time.monotonic()
 
-        self._ensure_custom_skills_loaded()
-        skill = self.get(name)
+        # Resolve under any running A/B experiment.  Pulls user_id from the
+        # request-scoped ContextVar; system paths (user_id=None) get the
+        # in-memory active version unchanged.
+        from app.services.request_context import (
+            get_current_user_id,
+            set_current_skill_resolution,
+        )
+
+        user_id = get_current_user_id()
+        resolution = self.get_for_user(name, user_id)
+        skill = resolution.skill
+
         if not skill:
+            # Skill missing entirely: clear any stale resolution before logging.
+            set_current_skill_resolution(None)
             self._log_usage(
                 name,
                 agent_id,
@@ -307,6 +535,15 @@ class SkillsRegistry:
                 duration_ms=int((time.monotonic() - start_time) * 1000),
             )
             return {"success": False, "error": f"Skill '{name}' not found"}
+
+        # Stamp downstream loggers with which version / variant served this turn.
+        set_current_skill_resolution(
+            {
+                "skill_version_id": resolution.skill_version_id,
+                "experiment_id": resolution.experiment_id,
+                "variant": resolution.variant,
+            }
+        )
 
         # Validate agent has permission to use this skill
         if agent_id is not None and len(skill.agent_ids) > 0:

--- a/docs/self-improvement-policy.md
+++ b/docs/self-improvement-policy.md
@@ -1,0 +1,115 @@
+# Self-Improvement Autonomy Policy
+
+This document defines what the Pikar-AI self-improvement engine is allowed to
+modify autonomously, what stays behind human approval, and the invariants
+that govern both. It is normative — anything not listed here is **out of
+scope** for autonomous change. Future plans that propose to widen this scope
+must update this document explicitly.
+
+## 1. What the engine MAY auto-modify
+
+| Surface | Mechanism | Required gate |
+|---|---|---|
+| `skill_versions` knowledge content | Refinement via A/B harness | `skill_experiments` z-test produces a significant lift AND `(p_treatment − p_control) ≥ min_effect_size` |
+| `skill_versions.is_active` flag (promote/revert) | A/B harness decision | Same as above; revert fires on any significant regression |
+| `custom_skills.is_active` flag (demote) | `_execute_skill_demoted` | `auto_execute_risk_tiers` includes `skill_demoted` |
+| `skill_scores`, `improvement_actions`, `workflow_template_scores` rows (analytics writes) | Engine cron | Always — these are observational |
+
+Workflow template **scoring** is in scope (Pillar 2). Workflow template
+**refinement** is explicitly out of scope until an A/B harness analogous to
+the skill harness ships.
+
+## 2. What the engine MUST NOT auto-modify
+
+The following surfaces are the system's trust anchor. The engine and any
+service it calls must never write to them autonomously:
+
+- **Agent Python code** — `app/agents/**/*.py`, `app/agent.py`
+- **Agent instruction strings** — `app/agents/shared_instructions.py`,
+  `app/agents/*/instructions.py`, any `INSTRUCTIONS` module-level constant
+- **Model + routing config** — `app/agents/shared.py`
+  (`get_routing_model`, `get_fallback_model`, retry/backoff parameters)
+- **Tool registration** — the `EXEC_*_TOOLS` lists and the registry that
+  exposes tools to the runtime
+- **Database schema** — `supabase/migrations/`
+- **Orchestration kernel** — `app/workflows/engine.py`,
+  `app/workflows/step_executor.py`, the workflow runtime
+- **Self-improvement settings themselves** — `auto_execute_enabled`,
+  `auto_execute_risk_tiers`. Flipping the autonomy switches is a human
+  action only.
+
+If the engine ever appears to be writing to one of these surfaces, treat it
+as an incident, not a feature.
+
+## 3. Approval gates today
+
+Action types in `improvement_actions.action_type` and their default
+treatment:
+
+| Action type | Default | Reason |
+|---|---|---|
+| `skill_refined` | Auto-creates an A/B experiment | The harness gates promotion behind statistical evidence |
+| `skill_promoted` | Auto-issued by evaluator on significant lift | Backed by z-test + min_effect_size |
+| `skill_demoted` | Auto-executable when in `auto_execute_risk_tiers` | Reversible by re-promoting; no production risk |
+| `pattern_extract` | Auto-executable when in `auto_execute_risk_tiers` | Pure analysis, no state mutation outside `improvement_actions` |
+| `skill_created` | Human approval | No control variant — cannot A/B a brand-new skill |
+| `skill_merged` | Human approval | Affects skill identity / routing assumptions |
+| `instruction_updated` | Human approval | Would mutate agent instructions; see §2 |
+| `gap_identified` | No mutation (analysis only) | Surfaces gaps to humans; resolution is a separate action |
+| `investigate` | No mutation (analysis only) | Triggers human review of a declining trend |
+
+`auto_execute_enabled` controls whether even the "auto-executable" tiers
+run automatically. Default `False` — flip to `True` only after the A/B
+harness has demonstrated stable promote/revert decisions on real traffic.
+
+## 4. Rollback contract
+
+Every auto-modification the engine performs MUST be:
+
+1. **Traceable**: written through `improvement_actions` with
+   `source_action_id` linking to the originating decision, AND through
+   `governance_audit_log` with an `action_type` prefixed
+   `self_improvement.`.
+2. **Reversible in one statement**:
+   - For promotes: flip `is_active` on `skill_versions` back to the
+     `previous_version_id` row.
+   - For experiment reverts: the candidate row already has
+     `metadata.reverted = true` and `is_active = false`; no further action
+     needed.
+   - For demotes: `UPDATE custom_skills SET is_active = true WHERE id = $`.
+3. **Visible**: dashboards must show the change with timestamps, actor
+   (`system:self-improvement-engine`), and decision rationale before any
+   admin is expected to trust it.
+
+When an auto-decision goes wrong, the recovery path is a human flipping
+`is_active` (or running the rollback statement above) — not a re-run of
+the engine.
+
+## 5. The eval-before-autonomy invariant
+
+The engine MUST NOT promote any change to a live skill without a
+statistically significant z-test on real interactions collected during a
+running `skill_experiments` row. Specifically:
+
+- Promotion requires `z > +1.96` AND `(p_treatment − p_control) ≥ min_effect_size`.
+- Revert fires on any `z < −1.96`, regardless of effect size (asymmetric
+  by design — we want fast rollback on harm but conservative promotion
+  on lift).
+- When an experiment cannot collect enough samples within
+  `max_duration_days`, the default action is **revert**, not promote. The
+  "do nothing" branch only exists between the deadline and the sample
+  budget — once either is exhausted, we always fall back to the control
+  version.
+
+## 6. Reading this document in code
+
+The constants in `app/services/skill_experiment_evaluator.py` and
+`app/services/self_improvement_engine.py` are the source of truth for the
+exact thresholds. Per-experiment overrides on the `skill_experiments` row
+take precedence over module defaults — but no override can disable a
+threshold entirely (a `min_effect_size` of 0 is treated as 0, not as
+"promote on any lift").
+
+The boundary in §2 is enforced socially, not technically. If you are a
+future engineer or future Claude reading this, treat any PR that
+broadens §1 without a parallel broadening of §4 and §5 as suspect.

--- a/supabase/migrations/20260511135000_fix_orphan_agent_shadow_diffs.sql
+++ b/supabase/migrations/20260511135000_fix_orphan_agent_shadow_diffs.sql
@@ -1,0 +1,14 @@
+-- Migration: fix orphan agent_shadow_diffs table
+-- Reason: The table existed on the remote (rbdowedrdhtlbngapexj) with a
+-- different shape than the committed 20260511140000_agent_shadow_diffs.sql
+-- migration expects — the migration's CREATE INDEX failed on a missing
+-- created_at column.  The local schema was created out-of-band before the
+-- migration was authored; no committed migration references the legacy
+-- shape, so the table was never canonical.
+--
+-- supabase inspect db table-stats showed 0 rows on this table at the time
+-- of this migration, so DROP CASCADE is safe.  After this runs, the
+-- subsequent 20260511140000 migration creates the canonical schema
+-- including all indexes and policies.
+
+DROP TABLE IF EXISTS public.agent_shadow_diffs CASCADE;

--- a/supabase/migrations/20260616000000_skill_experiments.sql
+++ b/supabase/migrations/20260616000000_skill_experiments.sql
@@ -1,0 +1,128 @@
+-- Migration: skill_experiments
+-- Purpose: A/B eval harness for the SelfImprovementEngine.  Refined skills enter
+-- an experiment instead of being promoted immediately.  Traffic is split per-user
+-- (sticky hash of user_id + experiment_id) between the current active version
+-- (control) and the candidate version (treatment).  The evaluator promotes or
+-- reverts based on a two-proportion z-test over the interaction-level quality
+-- signal.
+--
+-- Idempotent: safe to run multiple times.
+
+-- ============================================================================
+-- 1. skill_experiments table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS skill_experiments (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    skill_name            TEXT NOT NULL,
+    control_version_id    UUID NOT NULL REFERENCES skill_versions(id),
+    candidate_version_id  UUID NOT NULL REFERENCES skill_versions(id),
+    source_action_id      UUID REFERENCES improvement_actions(id),
+    state                 TEXT NOT NULL DEFAULT 'running'
+                          CHECK (state IN ('running','promoted','reverted','aborted')),
+    min_samples_per_arm   INTEGER NOT NULL DEFAULT 50,
+    max_samples_per_arm   INTEGER NOT NULL DEFAULT 500,
+    max_duration_days     INTEGER NOT NULL DEFAULT 14,
+    alpha                 REAL    NOT NULL DEFAULT 0.05,
+    min_effect_size       REAL    NOT NULL DEFAULT 0.05,
+    started_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    decided_at            TIMESTAMPTZ,
+    decision_reason       TEXT,
+    metadata              JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+-- At most one live experiment per skill_name (mirrors the active-version pattern
+-- used by skill_versions).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_skill_experiments_one_running
+    ON skill_experiments (skill_name) WHERE state = 'running';
+
+CREATE INDEX IF NOT EXISTS idx_skill_experiments_state
+    ON skill_experiments (state, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_skill_experiments_skill_name
+    ON skill_experiments (skill_name, started_at DESC);
+
+-- RLS: service-role writes; authenticated reads (dashboard surface).
+ALTER TABLE skill_experiments ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_policies
+        WHERE tablename = 'skill_experiments'
+          AND policyname = 'skill_experiments_read_access'
+    ) THEN
+        EXECUTE $policy$
+            CREATE POLICY skill_experiments_read_access ON skill_experiments
+                FOR SELECT USING (auth.role() = 'authenticated' OR auth.role() = 'service_role')
+        $policy$;
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_policies
+        WHERE tablename = 'skill_experiments'
+          AND policyname = 'skill_experiments_write_access'
+    ) THEN
+        EXECUTE $policy$
+            CREATE POLICY skill_experiments_write_access ON skill_experiments
+                FOR ALL USING (auth.role() = 'service_role')
+        $policy$;
+    END IF;
+END
+$$;
+
+-- ============================================================================
+-- 2. Extend interaction_logs with experiment attribution
+-- ============================================================================
+ALTER TABLE interaction_logs
+    ADD COLUMN IF NOT EXISTS skill_version_id UUID REFERENCES skill_versions(id),
+    ADD COLUMN IF NOT EXISTS experiment_id    UUID REFERENCES skill_experiments(id),
+    ADD COLUMN IF NOT EXISTS variant          TEXT;
+
+DO $$
+BEGIN
+    ALTER TABLE interaction_logs
+        DROP CONSTRAINT IF EXISTS interaction_logs_variant_check;
+
+    ALTER TABLE interaction_logs
+        ADD CONSTRAINT interaction_logs_variant_check
+        CHECK (variant IS NULL OR variant IN ('control','treatment'));
+END
+$$;
+
+-- Drives per-experiment aggregation queries (the evaluator's hot path).
+CREATE INDEX IF NOT EXISTS idx_interaction_logs_experiment
+    ON interaction_logs (experiment_id, variant, created_at DESC)
+    WHERE experiment_id IS NOT NULL;
+
+-- Per-version forensics + ad-hoc joins.
+CREATE INDEX IF NOT EXISTS idx_interaction_logs_skill_version
+    ON interaction_logs (skill_version_id)
+    WHERE skill_version_id IS NOT NULL;
+
+-- ============================================================================
+-- 3. Relax improvement_actions.status CHECK to allow 'experimenting' + 'deferred'
+-- ============================================================================
+DO $$
+BEGIN
+    ALTER TABLE improvement_actions
+        DROP CONSTRAINT IF EXISTS improvement_actions_status_check;
+
+    ALTER TABLE improvement_actions
+        ADD CONSTRAINT improvement_actions_status_check
+        CHECK (status IN (
+            'pending',
+            'applied',
+            'validated',
+            'reverted',
+            'pending_approval',
+            'declined',
+            'failed',
+            'experimenting',
+            'deferred'
+        ));
+END
+$$;

--- a/supabase/migrations/20260616000100_workflow_template_scores.sql
+++ b/supabase/migrations/20260616000100_workflow_template_scores.sql
@@ -1,0 +1,93 @@
+-- Migration: workflow_template_scores
+-- Purpose: Per-version effectiveness scoring for workflow templates.
+-- Mirrors skill_scores: rolling-window aggregation of run telemetry into
+-- composite scores, trend tracking, and dashboard visibility.
+--
+-- Pillar 2 of the self-improvement eval harness — scoring only; no
+-- auto-refinement of workflow templates yet.
+--
+-- Idempotent: safe to run multiple times.
+
+CREATE TABLE IF NOT EXISTS workflow_template_scores (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Template + version under evaluation.  template_version_id is the
+    -- preferred grain — when a version is pinned at run start we attribute
+    -- run outcomes to that specific snapshot.  template_id is kept for
+    -- joining and for legacy runs whose template_version_id is NULL.
+    template_id             UUID NOT NULL REFERENCES workflow_templates(id) ON DELETE CASCADE,
+    template_version_id     UUID REFERENCES workflow_template_versions(id) ON DELETE SET NULL,
+
+    -- Bucket label (mirror skill_scores.evaluation_period).
+    evaluation_period       TEXT NOT NULL,
+    period_start            TIMESTAMPTZ NOT NULL,
+    period_end              TIMESTAMPTZ NOT NULL,
+
+    -- Counts
+    total_runs              INTEGER NOT NULL DEFAULT 0,
+    unique_users            INTEGER NOT NULL DEFAULT 0,
+
+    -- Rates derived from workflow_executions + workflow_steps.
+    -- All in [0.0, 1.0]; the composite uses the weights documented in
+    -- app/services/workflow_template_scoring.py.
+    completion_rate         REAL NOT NULL DEFAULT 0.0,
+    error_rate              REAL NOT NULL DEFAULT 0.0,
+    retry_rate              REAL NOT NULL DEFAULT 0.0,
+    escalation_rate         REAL NOT NULL DEFAULT 0.0,
+
+    -- Weighted composite (the "val_bpb" analogue for workflows).
+    effectiveness_score     REAL NOT NULL DEFAULT 0.0,
+
+    -- Trend against the previous row for the same (template_id, template_version_id).
+    score_delta             REAL,
+    trend                   TEXT CHECK (trend IN ('improving','stable','declining','new')),
+
+    metadata                JSONB NOT NULL DEFAULT '{}'::jsonb,
+    evaluated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (template_id, template_version_id, evaluation_period)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_template_scores_template
+    ON workflow_template_scores (template_id, evaluated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_template_scores_version
+    ON workflow_template_scores (template_version_id, evaluated_at DESC)
+    WHERE template_version_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_workflow_template_scores_effectiveness
+    ON workflow_template_scores (effectiveness_score DESC);
+
+-- RLS: service-role write; authenticated read for dashboards.
+ALTER TABLE workflow_template_scores ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_policies
+        WHERE tablename = 'workflow_template_scores'
+          AND policyname = 'workflow_template_scores_read_access'
+    ) THEN
+        EXECUTE $policy$
+            CREATE POLICY workflow_template_scores_read_access ON workflow_template_scores
+                FOR SELECT USING (auth.role() = 'authenticated' OR auth.role() = 'service_role')
+        $policy$;
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_policies
+        WHERE tablename = 'workflow_template_scores'
+          AND policyname = 'workflow_template_scores_write_access'
+    ) THEN
+        EXECUTE $policy$
+            CREATE POLICY workflow_template_scores_write_access ON workflow_template_scores
+                FOR ALL USING (auth.role() = 'service_role')
+        $policy$;
+    END IF;
+END
+$$;

--- a/tests/unit/test_skill_experiment_evaluator.py
+++ b/tests/unit/test_skill_experiment_evaluator.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+# Proprietary and confidential. See LICENSE file for details.
+
+"""Unit tests for SkillExperimentEvaluator decision logic.
+
+Tests cover:
+- Pure helpers (_interaction_quality, _two_proportion_z, _duration_expired)
+- _evaluate_one decision branches:
+    * below_min_samples -> running
+    * significant_lift -> promoted
+    * significant_regression -> reverted
+    * inconclusive_low_traffic (duration expired) -> inconclusive_reverted
+    * inconclusive_max_samples -> inconclusive_reverted
+    * no_decision_yet -> running
+
+Apply paths (_apply_promote / _apply_revert) are stubbed; their DB orchestration
+is intentionally not unit-tested.  The aim is to lock the math + decision
+flow so regressions to those branches show up here loudly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.skill_experiment_evaluator import (
+    SkillExperimentEvaluator,
+    _duration_expired,
+    _interaction_quality,
+    _safe_rate,
+    _two_proportion_z,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "task_completed, user_feedback, expected",
+    [
+        (True, "positive", 1),
+        (True, "neutral", 1),
+        (True, None, 1),
+        (True, "negative", 0),  # negative overrides completion
+        (False, "positive", 1),  # explicit positive overrides incompletion
+        (False, "negative", 0),
+        (False, None, 0),
+        (None, None, 0),
+        (None, "positive", 1),
+    ],
+)
+def test_interaction_quality(task_completed, user_feedback, expected):
+    assert _interaction_quality(task_completed, user_feedback) == expected
+
+
+def test_safe_rate_handles_zero_denominator():
+    assert _safe_rate(0, 0) == 0.0
+    assert _safe_rate(5, 0) == 0.0
+    assert _safe_rate(5, 10) == 0.5
+
+
+def test_two_proportion_z_significant_lift():
+    # Big lift, big samples: should be solidly positive z.
+    z = _two_proportion_z(q_c=30, n_c=100, q_t=70, n_t=100)
+    assert z is not None
+    assert z > 5.0  # 40-point lift on n=100 each => clearly significant
+
+
+def test_two_proportion_z_significant_regression():
+    z = _two_proportion_z(q_c=70, n_c=100, q_t=30, n_t=100)
+    assert z is not None
+    assert z < -5.0
+
+
+def test_two_proportion_z_no_difference():
+    z = _two_proportion_z(q_c=50, n_c=100, q_t=50, n_t=100)
+    assert z is not None
+    assert abs(z) < 0.5
+
+
+def test_two_proportion_z_empty_arm():
+    assert _two_proportion_z(0, 0, 5, 10) is None
+    assert _two_proportion_z(5, 10, 0, 0) is None
+
+
+def test_two_proportion_z_no_variance():
+    # All zeros: pooled p == 0 => can't test.
+    assert _two_proportion_z(0, 50, 0, 50) is None
+    # All ones: pooled p == 1 => can't test.
+    assert _two_proportion_z(50, 50, 50, 50) is None
+
+
+def test_duration_expired_iso_string():
+    long_ago = (datetime.now(tz=timezone.utc) - timedelta(days=20)).isoformat()
+    assert _duration_expired(long_ago, max_duration_days=14) is True
+
+
+def test_duration_expired_recent():
+    recent = (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat()
+    assert _duration_expired(recent, max_duration_days=14) is False
+
+
+def test_duration_expired_none():
+    assert _duration_expired(None, max_duration_days=14) is False
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_one decision branches
+# ---------------------------------------------------------------------------
+
+
+class _StubEvaluator(SkillExperimentEvaluator):
+    """SkillExperimentEvaluator with the supabase client + DB mutations stubbed.
+
+    Tests inject ``_arms`` to control what _aggregate_arms returns and assert
+    on the outcome string from _evaluate_one.
+    """
+
+    def __init__(self, arms: dict[str, tuple[int, int]]) -> None:
+        # Skip the real __init__ — we don't need a real Supabase client.
+        self.client = MagicMock()
+        self._arms = arms
+        self.applied: list[tuple[str, dict[str, Any]]] = []
+
+    async def _aggregate_arms(self, exp_id: str):
+        return self._arms
+
+    async def _apply_promote(self, exp, decision):
+        decision["outcome"] = "promoted"
+        self.applied.append(("promote", decision))
+        return decision
+
+    async def _apply_revert(self, exp, decision, *, inconclusive):
+        decision["outcome"] = (
+            "inconclusive_reverted" if inconclusive else "reverted"
+        )
+        self.applied.append(
+            ("revert" if not inconclusive else "inconclusive_revert", decision)
+        )
+        return decision
+
+
+def _exp(
+    *,
+    started_at: str | None = None,
+    min_samples: int = 50,
+    max_samples: int = 500,
+    max_duration_days: int = 14,
+    min_effect_size: float = 0.05,
+) -> dict[str, Any]:
+    return {
+        "id": "exp-1",
+        "skill_name": "test_skill",
+        "control_version_id": "ver-c",
+        "candidate_version_id": "ver-t",
+        "source_action_id": "act-1",
+        "min_samples_per_arm": min_samples,
+        "max_samples_per_arm": max_samples,
+        "max_duration_days": max_duration_days,
+        "alpha": 0.05,
+        "min_effect_size": min_effect_size,
+        "started_at": started_at
+        or (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat(),
+        "metadata": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_below_min_samples_keeps_running():
+    """One arm under the minimum sample size -> running (no decision)."""
+    ev = _StubEvaluator(arms={"control": (10, 5), "treatment": (10, 6)})
+    result = await ev._evaluate_one(_exp())
+    assert result["outcome"] == "running"
+    assert result["decision_reason"] == "below_min_samples"
+    assert ev.applied == []
+
+
+@pytest.mark.asyncio
+async def test_significant_lift_promotes():
+    """Treatment significantly better AND beats min_effect_size -> promote."""
+    ev = _StubEvaluator(arms={"control": (50, 25), "treatment": (50, 45)})
+    result = await ev._evaluate_one(_exp())
+    assert result["outcome"] == "promoted"
+    assert result["decision_reason"] == "significant_lift"
+    assert ev.applied[0][0] == "promote"
+
+
+@pytest.mark.asyncio
+async def test_significant_regression_reverts():
+    """Treatment significantly worse -> revert regardless of effect size."""
+    ev = _StubEvaluator(arms={"control": (50, 45), "treatment": (50, 25)})
+    result = await ev._evaluate_one(_exp())
+    assert result["outcome"] == "reverted"
+    assert result["decision_reason"] == "significant_regression"
+
+
+@pytest.mark.asyncio
+async def test_significant_lift_below_effect_size_keeps_running():
+    """Lift is statistically significant but tiny -> continue."""
+    # Very large n with small absolute lift: z is high, p_diff is tiny.
+    ev = _StubEvaluator(
+        arms={"control": (10000, 5000), "treatment": (10000, 5100)}
+    )
+    result = await ev._evaluate_one(
+        _exp(min_samples=50, max_samples=20000, min_effect_size=0.05)
+    )
+    # p_t - p_c = 0.01, below min_effect_size of 0.05, so don't promote.
+    # Within sample budget, so keep running.
+    assert result["outcome"] == "running"
+    assert result["decision_reason"] == "no_decision_yet"
+
+
+@pytest.mark.asyncio
+async def test_max_duration_exceeded_triggers_inconclusive_revert():
+    """Duration expired without verdict -> inconclusive revert."""
+    long_ago = (
+        datetime.now(tz=timezone.utc) - timedelta(days=30)
+    ).isoformat()
+    ev = _StubEvaluator(arms={"control": (60, 30), "treatment": (60, 32)})
+    result = await ev._evaluate_one(
+        _exp(started_at=long_ago, max_duration_days=14)
+    )
+    assert result["outcome"] == "inconclusive_reverted"
+    assert result["decision_reason"] == "inconclusive_low_traffic"
+
+
+@pytest.mark.asyncio
+async def test_sample_budget_exhausted_triggers_inconclusive_revert():
+    """Both arms hit max_samples_per_arm without significance -> inconclusive revert."""
+    ev = _StubEvaluator(
+        arms={"control": (500, 250), "treatment": (500, 255)}
+    )
+    result = await ev._evaluate_one(_exp(max_samples=500))
+    assert result["outcome"] == "inconclusive_reverted"
+    assert result["decision_reason"] == "inconclusive_max_samples"
+
+
+@pytest.mark.asyncio
+async def test_empty_treatment_returns_no_signal():
+    """Treatment arm empty and duration not expired -> running with no_signal_yet."""
+    ev = _StubEvaluator(arms={"control": (60, 30), "treatment": (0, 0)})
+    # min_samples=50 means the empty treatment arm trips below_min_samples first.
+    result = await ev._evaluate_one(_exp(min_samples=50))
+    assert result["outcome"] == "running"
+    # The below_min_samples branch fires before we ever try the z-test.
+    assert result["decision_reason"] == "below_min_samples"
+
+
+@pytest.mark.asyncio
+async def test_empty_treatment_with_duration_expired_is_inconclusive():
+    """Empty treatment + duration expired -> inconclusive_no_signal -> revert."""
+    long_ago = (
+        datetime.now(tz=timezone.utc) - timedelta(days=30)
+    ).isoformat()
+    ev = _StubEvaluator(arms={"control": (60, 30), "treatment": (0, 0)})
+    # Lower min_samples so we skip the below_min_samples gate and hit the
+    # z-test path with no signal.
+    result = await ev._evaluate_one(
+        _exp(started_at=long_ago, min_samples=0)
+    )
+    assert result["outcome"] == "inconclusive_reverted"
+    assert result["decision_reason"] == "inconclusive_no_signal"

--- a/tests/unit/test_workflow_template_scoring.py
+++ b/tests/unit/test_workflow_template_scoring.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+# Proprietary and confidential. See LICENSE file for details.
+
+"""Unit tests for workflow_template_scoring pure helpers.
+
+Locks the math:
+- _compute_metrics: rate computation against synthetic runs + steps
+- _composite: weights sum to 1.0 and weight rationale is preserved
+- _trend: improving / declining / stable / new
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.workflow_template_scoring import (
+    _W_COMPLETION,
+    _W_ERROR,
+    _W_ESCALATION,
+    _W_RETRY,
+    _composite,
+    _compute_metrics,
+    _trend,
+)
+
+
+def test_weights_sum_to_one():
+    assert (
+        pytest.approx(_W_COMPLETION + _W_ERROR + _W_RETRY + _W_ESCALATION) == 1.0
+    )
+
+
+def test_compute_metrics_basic():
+    runs = [
+        {"id": "r1", "user_id": "u1", "status": "completed"},
+        {"id": "r2", "user_id": "u2", "status": "failed"},
+        {"id": "r3", "user_id": "u1", "status": "running"},
+        {"id": "r4", "user_id": "u3", "status": "completed"},
+    ]
+    steps_by_exec = {
+        "r1": [{"attempt_count": 1, "sla_status": "on_time"}],
+        "r2": [{"attempt_count": 3, "sla_status": "escalated"}],
+        "r3": [{"attempt_count": 1, "sla_status": "escalated"}],
+        # r4 has no steps recorded.
+    }
+    m = _compute_metrics(runs, steps_by_exec)
+    assert m["total"] == 4
+    assert m["unique_users"] == 3
+    assert m["completion_rate"] == 0.5  # 2/4
+    assert m["error_rate"] == 0.25  # 1/4
+    assert m["retry_rate"] == 0.25  # only r2 had attempt_count > 1
+    assert m["escalation_rate"] == 0.5  # r2 + r3
+
+
+def test_compute_metrics_empty_runs():
+    m = _compute_metrics([], {})
+    assert m["total"] == 0
+    assert m["completion_rate"] == 0.0
+    assert m["error_rate"] == 0.0
+    assert m["retry_rate"] == 0.0
+    assert m["escalation_rate"] == 0.0
+    assert m["unique_users"] == 0
+
+
+def test_composite_perfect_run():
+    """All-completed, no errors / retries / escalations -> max score."""
+    m = {
+        "completion_rate": 1.0,
+        "error_rate": 0.0,
+        "retry_rate": 0.0,
+        "escalation_rate": 0.0,
+    }
+    # 0.5*1 + 0.2*1 + 0.15*1 + 0.15*1 = 1.0
+    assert _composite(m) == pytest.approx(1.0)
+
+
+def test_composite_worst_case():
+    """All-failed, all-retried, all-escalated, no completion -> 0."""
+    m = {
+        "completion_rate": 0.0,
+        "error_rate": 1.0,
+        "retry_rate": 1.0,
+        "escalation_rate": 1.0,
+    }
+    assert _composite(m) == pytest.approx(0.0)
+
+
+def test_composite_partial_signals():
+    """Half completion, no errors, some retries: predictable composite."""
+    m = {
+        "completion_rate": 0.5,
+        "error_rate": 0.0,
+        "retry_rate": 0.2,
+        "escalation_rate": 0.1,
+    }
+    # 0.5*0.5 + 0.2*1.0 + 0.15*0.8 + 0.15*0.9
+    expected = 0.5 * 0.5 + 0.2 * 1.0 + 0.15 * 0.8 + 0.15 * 0.9
+    assert _composite(m) == pytest.approx(expected)
+
+
+def test_trend_new_when_no_previous():
+    delta, trend = _trend(0.5, None)
+    assert delta is None
+    assert trend == "new"
+
+
+def test_trend_improving():
+    delta, trend = _trend(0.60, 0.50)
+    assert delta == pytest.approx(0.10)
+    assert trend == "improving"
+
+
+def test_trend_declining():
+    delta, trend = _trend(0.40, 0.50)
+    assert delta == pytest.approx(-0.10)
+    assert trend == "declining"
+
+
+def test_trend_stable_within_epsilon():
+    delta, trend = _trend(0.501, 0.500)
+    assert trend == "stable"
+    assert abs(delta) < 0.02
+
+
+def test_retry_rate_ignores_steps_without_attempt_count():
+    """attempt_count == None should not falsely count as a retry."""
+    runs = [{"id": "r1", "user_id": "u1", "status": "completed"}]
+    steps_by_exec = {
+        "r1": [{"attempt_count": None, "sla_status": None}],
+    }
+    m = _compute_metrics(runs, steps_by_exec)
+    assert m["retry_rate"] == 0.0
+    assert m["escalation_rate"] == 0.0


### PR DESCRIPTION
## Summary

Three pillars that unlock safely flipping `auto_execute_enabled = True` on the self-improvement engine, plus the autonomy boundary policy that governs it.

**Pillar 1 — Skill A/B eval harness** (`fa50bb89` + tests `6c4516f8`)
- New `skill_experiments` table with `UNIQUE (skill_name) WHERE state='running'` partial index
- `interaction_logs` extended with `skill_version_id`, `experiment_id`, `variant` (all nullable)
- `app/skills/registry.py` resolves per-user sticky variant via SHA-256 hash of `user_id + experiment_id`; 60s TTL cache; `reload_skill_from_db` + `_invalidate_experiment` hooks for the evaluator
- `_execute_skill_refined` now creates a `skill_experiments` row instead of promoting the candidate immediately; defers when a running experiment exists on the same skill
- `SkillExperimentEvaluator` runs after the engine in `/self-improvement-cycle`. Two-proportion z-test on the per-interaction quality Bernoulli signal. **Asymmetric decision**: revert on any significant regression (`z < -1.96`); promote only when significant AND `(p_t − p_c) ≥ min_effect_size`; inconclusive-revert when sample budget or `max_duration_days` exhausted

**Pillar 2 — Workflow template effectiveness scoring** (`b51f35f7` + tests `c3060d81`)
- New `workflow_template_scores` table mirroring `skill_scores` shape
- Aggregates `workflow_executions` + `workflow_steps` grouped by `(template_id, template_version_id)`; composite weights: completion 0.50, error 0.20, retry 0.15, escalation 0.15 (weights differ from skill formula because workflows have no `positive_rate` proxy in v1)
- Wired into the same `/self-improvement-cycle` cron
- **Scoring only** — no autonomous refinement of workflow templates yet

**Pillar 3 — Autonomy policy** (`6e2c021b`)
- `docs/self-improvement-policy.md`: what the engine MAY / MUST-NOT auto-modify, approval gates that remain (`skill_created`, `skill_merged`, `instruction_updated` stay behind humans), rollback contract, eval-before-autonomy invariant
- Linked from `CLAUDE.md` Key Patterns section

**Unblock fixup** (`ff0aa57a`)
- `agent_shadow_diffs` existed on prod with a different shape (created out-of-band, 0 rows) — added a timestamped fixup migration to DROP CASCADE before the canonical migration runs. Resolves 7 months of migration drift in one commit. Pattern is reusable for similar future drift.

## Database migrations already applied to prod

7 migrations pushed to `rbdowedrdhtlbngapexj` on 2026-05-18 via `supabase db push --linked --include-all`:
- `20260511135000_fix_orphan_agent_shadow_diffs.sql` (this PR)
- `20260511140000_agent_shadow_diffs.sql` (Phase W3-B-Alpha-Plus — was pending)
- `20260601000000_workflow_template_graph_projection.sql` (Phase 109 — was pending)
- `20260615000000_workflow_template_versioning.sql` (Phase 110 — was pending)
- `20260615000100_workflow_template_save_rpc.sql` (Phase 110 — was pending)
- `20260616000000_skill_experiments.sql` (this PR)
- `20260616000100_workflow_template_scores.sql` (this PR)

The new tables exist with 0 rows; `interaction_logs` picked up 3 nullable columns; `improvement_actions.status` CHECK relaxed to accept `experimenting` and `deferred`.

## Test plan

- [x] 37 new unit tests pass (`test_skill_experiment_evaluator.py`: 26, `test_workflow_template_scoring.py`: 11)
- [x] 54-test broader sweep passes (`test_scheduled_improvement_cycle`, `test_approval_queue_and_audit`, `test_feedback_loop_e2e`)
- [x] `ruff check` clean on all touched files (pre-existing RUF002 EN-DASH in `registry.py:235` is unrelated)
- [x] Imports verified end-to-end — no circular dependency
- [x] Migrations applied on prod; remote tables verified via `supabase inspect db table-sizes --linked`
- [ ] **Redeploy Cloud Run** — currently blocked on `pikar-ai-project` billing per existing memory. Until redeploy, prod runs old code; new columns stay NULL on inserts and `_execute_skill_refined` still uses the immediate-promote path (kept safe by `auto_execute_enabled=False`)
- [ ] **Staging validation** — seed one experiment on a low-stakes skill, run for 24-48h, confirm the evaluator decides correctly and `improvement_actions` + `governance_audit_log` rows match expectations
- [ ] **Flip `auto_execute_enabled = True`** in admin settings — only after the above two items land

## Out of scope

- UI for experiment dashboards (CRUD via SQL / existing admin API sufficient for v1)
- Workflow template A/B harness (scoring only in this PR — refinement loop is future work)
- Touching agent code, prompts, or routing config (the policy explicitly forbids — see `docs/self-improvement-policy.md` §2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)