### PR TITLE
Phase 113: Data Agent adoption (confidence + cache + claims + semantic search + contradictions)

### DIFF
--- a/app/agent.py
+++ b/app/agent.py
@@ -107,6 +107,9 @@ from app.agents.tools.ui_widgets import UI_WIDGET_TOOLS
 # Import workflow tools
 from app.agents.tools.workflows import WORKFLOW_TOOLS
 
+# Import cross-agent semantic claim search tool (113-04)
+from app.agents.tools.intelligence_search import INTELLIGENCE_SEARCH_TOOLS
+
 # Import knowledge injection tools
 from app.orchestration.knowledge_tools import KNOWLEDGE_INJECTION_TOOLS
 from app.personas.prompt_fragments import build_persona_policy_block
@@ -278,6 +281,7 @@ _EXECUTIVE_TOOLS = _sanitize(
             create_task,
             audit_user_setup_tool,
             *KNOWLEDGE_INJECTION_TOOLS,
+            *INTELLIGENCE_SEARCH_TOOLS,
             *NOTIFICATION_TOOLS,
             *APP_BUILDER_TOOLS,
             *WORKFLOW_TOOLS,

--- a/app/agents/data/tools.py
+++ b/app/agents/data/tools.py
@@ -231,6 +231,8 @@ async def cohort_analysis(months: int = 6) -> dict:
         executive summary, and chart data for rendering.
     """
     from app.services.cohort_analysis_service import CohortAnalysisService
+    from app.services.intelligence.confidence import to_band
+    from app.services.intelligence.presets.data import data_confidence
     from app.services.request_context import get_current_user_id
 
     try:
@@ -246,7 +248,34 @@ async def cohort_analysis(months: int = 6) -> dict:
                 ),
                 "data": result,
             }
-        return {"success": True, "data": result}
+
+        # --- confidence scoring (Phase 113-01 pilot) ---
+        # sample_size: total unique customers across all cohorts
+        sample_size: int = result.get("retention", {}).get("total_customers", 0)
+        # missing_pct: CohortAnalysisService doesn't surface a field-missing rate
+        # yet; default to 0.0 (Stripe data is well-formed).  TODO: wire real value.
+        missing_pct: float = 0.0
+        # sigma_distance: no baseline comparison available yet from the service.
+        # Default to 0.0 (no anomaly detected).  TODO: wire real sigma once
+        # CohortAnalysisService computes a trend baseline.
+        sigma_distance: float = 0.0
+        # data_age_hours: conservative default for near-real-time Stripe sync.
+        data_age_hours: float = 1.0
+
+        confidence_score: float = data_confidence(
+            sample_size,
+            missing_pct,
+            sigma_distance,
+            data_age_hours,
+        )
+        band = to_band(confidence_score)
+
+        return {
+            "success": True,
+            "data": result,
+            "confidence": confidence_score,
+            "band": band,
+        }
     except Exception as e:
         return {"success": False, "error": str(e)}
 

--- a/app/agents/data/tools.py
+++ b/app/agents/data/tools.py
@@ -217,31 +217,99 @@ async def suggest_data_reports(provider: str | None = None) -> dict:
         }
 
 
+async def _cohort_entity_id(months: int):
+    """Build / fetch the kg_entities row representing this cohort window.
+
+    Idempotent upsert keyed on (canonical_name, entity_type). Returns a UUID
+    identifying the entity so the graph-tier cache can look up fresh claims.
+
+    Args:
+        months: Cohort window in months (e.g. 6 → ``cohort_window_6m``).
+
+    Returns:
+        UUID of the kg_entities row for this cohort window.
+    """
+    from app.services.intelligence import get_or_create_entity
+
+    return await get_or_create_entity(
+        canonical_name=f"cohort_window_{months}m",
+        entity_type="metric",
+        domains=["data"],
+    )
+
+
 async def cohort_analysis(months: int = 6) -> dict:
     """Run full SaaS cohort analysis: retention, LTV, and churn by signup month.
 
     Analyzes Stripe transaction data to identify customer cohorts and compute
     retention rates, lifetime value, and churn rates per signup month.
 
+    Two-tier cache wired in Plan 113-02:
+    - Graph tier: short-circuits on a fresh ``cohort_summary`` claim in
+      kg_findings (24 h freshness window). Returns from cache without calling
+      CohortAnalysisService or Stripe.
+    - Redis tier: ``_fetch_stripe_revenue`` inside CohortAnalysisService
+      caches its DB result for 300 s so repeated calls within the TTL skip
+      the financial_records query.
+
     Args:
         months: Number of months of history to analyze (default 6).
 
     Returns:
         Dictionary with retention matrix, LTV by cohort, churn rates,
-        executive summary, and chart data for rendering.
+        executive summary, and chart data for rendering. Includes
+        ``from_cache`` (bool) and ``cache_tier`` (str | None) fields.
     """
     from app.services.cohort_analysis_service import CohortAnalysisService
+    from app.services.intelligence import find_claims, should_query_graph
     from app.services.intelligence.confidence import to_band
     from app.services.intelligence.presets.data import data_confidence
     from app.services.request_context import get_current_user_id
 
     try:
+        # ------------------------------------------------------------------
+        # Graph-tier cache check (Plan 113-02)
+        # ------------------------------------------------------------------
+        entity_id = await _cohort_entity_id(months)
+        graph_decision = await should_query_graph(
+            entity_id=entity_id,
+            claim_type="cohort_summary",
+            agent_id="data",
+            freshness_threshold_hours=24.0,
+        )
+        if graph_decision.verdict == "fresh":
+            claims = await find_claims(
+                entity_id=entity_id,
+                claim_type="cohort_summary",
+                agent_id="data",
+                limit=1,
+            )
+            if claims:
+                c = claims[0]
+                return {
+                    "success": True,
+                    "from_cache": True,
+                    "cache_tier": "graph",
+                    "finding_text": c.finding_text,
+                    "confidence": c.confidence,
+                    "band": c.band,
+                    "freshness_hours": graph_decision.freshness_hours,
+                    "sources": [s.model_dump(exclude_none=True) for s in c.sources],
+                }
+            # No claim rows despite fresh verdict (edge case) — fall through
+            # to computation so the caller always gets a meaningful response.
+
+        # ------------------------------------------------------------------
+        # Normal computation path
+        # ------------------------------------------------------------------
         service = CohortAnalysisService()
         user_id = get_current_user_id() or "anonymous"
         result = await service.full_cohort_analysis(user_id, months)
         if result.get("retention", {}).get("total_customers", 0) == 0:
             return {
                 "success": True,
+                "from_cache": False,
+                "cache_tier": None,
                 "message": (
                     "No Stripe revenue data found. Connect your Stripe account and "
                     "ensure financial_records are synced to run cohort analysis."
@@ -272,6 +340,8 @@ async def cohort_analysis(months: int = 6) -> dict:
 
         return {
             "success": True,
+            "from_cache": False,
+            "cache_tier": None,
             "data": result,
             "confidence": confidence_score,
             "band": band,
@@ -403,9 +473,7 @@ async def query_usage(
         return {"success": False, "error": str(e), "events": [], "count": 0}
 
 
-def _aggregate_events(
-    events: list[dict], group_by: str
-) -> tuple[dict, dict]:
+def _aggregate_events(events: list[dict], group_by: str) -> tuple[dict, dict]:
     """Post-process events list into aggregated counts and chart data.
 
     Args:

--- a/app/agents/data/tools.py
+++ b/app/agents/data/tools.py
@@ -363,6 +363,7 @@ async def cohort_analysis(months: int = 6) -> dict:
                     sources=[{"kind": "stripe_row", "ref": f"cohort_window_{months}m"}],
                     agent_id="data",
                     claim_type="cohort_summary",
+                    embed=True,
                 )
             except Exception as _e:
                 logger.warning("cohort_summary claim write failed: %s", _e)

--- a/app/agents/data/tools.py
+++ b/app/agents/data/tools.py
@@ -7,6 +7,9 @@
 """Tools for the Data Analysis Agent."""
 
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 async def nl_data_query(question: str) -> dict:
@@ -337,6 +340,77 @@ async def cohort_analysis(months: int = 6) -> dict:
             data_age_hours,
         )
         band = to_band(confidence_score)
+
+        # ------------------------------------------------------------------
+        # Claim emission (Plan 113-03) — secondary persistence.
+        # These writes are wrapped in try/except because a graph-write failure
+        # must NOT deny the user their cohort result. This is a deliberate
+        # exception to the spec's "writes fail loudly" rule, applied only here
+        # because claim emission is downstream of primary delivery.
+        # ------------------------------------------------------------------
+        from app.services.intelligence import write_claim, write_claims
+        from app.services.intelligence.schemas import ClaimPayload, ClaimSource
+
+        # Summary claim — powers the graph-tier short-circuit on next call
+        exec_summary = str(result.get("executive_summary", "")).strip()
+        if exec_summary:
+            try:
+                await write_claim(
+                    entity_id=entity_id,
+                    domain="data",
+                    finding_text=exec_summary,
+                    confidence=confidence_score,
+                    sources=[{"kind": "stripe_row", "ref": f"cohort_window_{months}m"}],
+                    agent_id="data",
+                    claim_type="cohort_summary",
+                )
+            except Exception as _e:
+                logger.warning("cohort_summary claim write failed: %s", _e)
+
+        # Per-month retention claims — fine-grained, enables 113-04 semantic search.
+        # retention.cohorts shape: {cohort_month: {"month_0": 100.0, "month_1": X, ...}}
+        # month_0 = acquisition month (always 100%) — skip it; emit month_1..month_12 only.
+        retention_cohorts = result.get("retention", {}).get("cohorts", {})
+        payloads: list[ClaimPayload] = []
+        for cohort_month, month_rates in (retention_cohorts.items() if isinstance(retention_cohorts, dict) else []):
+            if not isinstance(month_rates, dict):
+                continue
+            for month_key, retention_rate in month_rates.items():
+                # month_key is like "month_0", "month_1", ...
+                if not isinstance(month_key, str) or not month_key.startswith("month_"):
+                    continue
+                try:
+                    mn = int(month_key.split("_", 1)[1])
+                except (IndexError, ValueError):
+                    continue
+                if mn < 1 or mn > 12:
+                    # Skip month_0 (acquisition) and out-of-range values
+                    continue
+                try:
+                    rate = float(retention_rate)
+                except (TypeError, ValueError):
+                    continue
+                payloads.append(ClaimPayload(
+                    entity_id=entity_id,
+                    domain="data",
+                    finding_text=(
+                        f"Cohort {cohort_month} month-{mn} retention = "
+                        f"{rate:.1f}%"
+                    ),
+                    confidence=confidence_score,
+                    sources=[ClaimSource(
+                        kind="stripe_row",
+                        ref=f"cohort:{cohort_month}",
+                    )],
+                    agent_id="data",
+                    claim_type=f"cohort_retention_m{mn}",
+                ))
+
+        if payloads:
+            try:
+                await write_claims(payloads)
+            except Exception as _e:
+                logger.warning("cohort_retention bulk write failed: %s", _e)
 
         return {
             "success": True,

--- a/app/agents/tools/intelligence_search.py
+++ b/app/agents/tools/intelligence_search.py
@@ -1,0 +1,55 @@
+"""ADK tool: cross-agent semantic claim search."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def search_agent_claims(
+    query: str,
+    agent_id: str | None = None,
+    claim_type: str | None = None,
+    top_k: int = 10,
+) -> dict[str, Any]:
+    """Search all agents' knowledge-graph claims by semantic similarity.
+
+    Args:
+        query: Natural-language search string.
+        agent_id: Optional — restrict to a specific agent.
+        claim_type: Optional — restrict to a single claim_type.
+        top_k: Max results returned. Default 10; capped at 100.
+
+    Returns:
+        Dict with results list and count int. See docs/intelligence/claim-types.md.
+    """
+    from app.services.intelligence import search_claims_semantic
+
+    try:
+        hits = await search_claims_semantic(
+            query=query, agent_id=agent_id, claim_type=claim_type, top_k=top_k,
+        )
+    except Exception as e:
+        logger.warning("search_agent_claims failed: %s", e)
+        return {"results": [], "count": 0, "error": str(e)}
+
+    results: list[dict[str, Any]] = []
+    for claim, similarity in hits:
+        results.append({
+            "finding_text": claim.finding_text,
+            "confidence": claim.confidence,
+            "band": claim.band,
+            "agent_id": claim.agent_id,
+            "claim_type": claim.claim_type,
+            "domain": claim.domain,
+            "similarity": similarity,
+            "sources": [s.model_dump(exclude_none=True) for s in claim.sources],
+            "freshness_at": claim.freshness_at.isoformat(),
+        })
+
+    return {"results": results, "count": len(results)}
+
+
+INTELLIGENCE_SEARCH_TOOLS = [search_agent_claims]

--- a/app/agents/tools/intelligence_search.py
+++ b/app/agents/tools/intelligence_search.py
@@ -29,7 +29,10 @@ async def search_agent_claims(
 
     try:
         hits = await search_claims_semantic(
-            query=query, agent_id=agent_id, claim_type=claim_type, top_k=top_k,
+            query=query,
+            agent_id=agent_id,
+            claim_type=claim_type,
+            top_k=top_k,
         )
     except Exception as e:
         logger.warning("search_agent_claims failed: %s", e)
@@ -37,17 +40,19 @@ async def search_agent_claims(
 
     results: list[dict[str, Any]] = []
     for claim, similarity in hits:
-        results.append({
-            "finding_text": claim.finding_text,
-            "confidence": claim.confidence,
-            "band": claim.band,
-            "agent_id": claim.agent_id,
-            "claim_type": claim.claim_type,
-            "domain": claim.domain,
-            "similarity": similarity,
-            "sources": [s.model_dump(exclude_none=True) for s in claim.sources],
-            "freshness_at": claim.freshness_at.isoformat(),
-        })
+        results.append(
+            {
+                "finding_text": claim.finding_text,
+                "confidence": claim.confidence,
+                "band": claim.band,
+                "agent_id": claim.agent_id,
+                "claim_type": claim.claim_type,
+                "domain": claim.domain,
+                "similarity": similarity,
+                "sources": [s.model_dump(exclude_none=True) for s in claim.sources],
+                "freshness_at": claim.freshness_at.isoformat(),
+            }
+        )
 
     return {"results": results, "count": len(results)}
 

--- a/app/rag/embedding_service.py
+++ b/app/rag/embedding_service.py
@@ -33,6 +33,17 @@ logger = logging.getLogger(__name__)
 EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-004")
 EMBEDDING_DIMENSION = 768
 EMBEDDING_TASK_TYPE = os.getenv("EMBEDDING_TASK_TYPE", "RETRIEVAL_DOCUMENT")
+# Newer Gemini embedding models (gemini-embedding-001, gemini-embedding-2) default
+# to higher native dimensions but accept output_dimensionality to match the
+# stored vector(768) column. text-embedding-004 ignores this field.
+_EMBEDDING_OUTPUT_DIMENSIONALITY_RAW = (
+    os.getenv("EMBEDDING_OUTPUT_DIMENSIONALITY") or ""
+).strip()
+EMBEDDING_OUTPUT_DIMENSIONALITY: int | None = (
+    int(_EMBEDDING_OUTPUT_DIMENSIONALITY_RAW)
+    if _EMBEDDING_OUTPUT_DIMENSIONALITY_RAW.isdigit()
+    else None
+)
 EMBEDDING_QUOTA_COOLDOWN_SECONDS = max(
     0, int(os.getenv("EMBEDDING_QUOTA_COOLDOWN_SECONDS", "900"))
 )
@@ -242,6 +253,8 @@ def _build_embed_params(contents: Any) -> dict:
     config: dict[str, Any] = {}
     if EMBEDDING_TASK_TYPE:
         config["taskType"] = EMBEDDING_TASK_TYPE
+    if EMBEDDING_OUTPUT_DIMENSIONALITY:
+        config["outputDimensionality"] = EMBEDDING_OUTPUT_DIMENSIONALITY
     if config:
         params["config"] = config
     return params

--- a/app/services/cohort_analysis_service.py
+++ b/app/services/cohort_analysis_service.py
@@ -26,6 +26,53 @@ from app.services.supabase_async import execute_async
 logger = logging.getLogger(__name__)
 
 
+async def _fetch_stripe_transactions(months: int, user_id: str) -> list[dict[str, Any]]:
+    """Fetch Stripe revenue rows for the cohort window with Redis caching.
+
+    Wraps CohortAnalysisService._fetch_stripe_revenue at the module level so the
+    result can be cached in Redis independently of the service instance lifecycle.
+    TTL of 300 s (5 min) — Stripe financial_records are append-only so a short
+    cache is appropriate for the recent window.
+
+    Cache key: ``stripe:cohort_raw:{months}m:{user_id}``
+
+    On Redis miss or stale verdict, falls through to the real DB query and
+    stores the result. On Redis failure the function degrades silently (returns
+    live data).
+
+    Args:
+        months: Number of months of history to fetch.
+        user_id: Pikar user ID whose financial_records to query.
+
+    Returns:
+        List of financial_record dicts.
+    """
+    from app.services.cache import get_cache_service
+    from app.services.intelligence import should_call_external
+
+    cache_key = f"stripe:cohort_raw:{months}m:{user_id}"
+    decision = await should_call_external(cache_key=cache_key, ttl_seconds=300)
+
+    if decision.verdict == "fresh":
+        cache = get_cache_service()
+        value, _age = await cache.get_with_age(cache_key)
+        if value is not None:
+            return value  # type: ignore[return-value]
+
+    # Cache miss, stale, or Redis failure — fetch from DB
+    service = CohortAnalysisService()
+    rows = await service._fetch_stripe_revenue(user_id, months)
+
+    # Best-effort cache write; failures are silent
+    try:
+        cache = get_cache_service()
+        await cache.set_with_age(cache_key, rows, ttl=300)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("_fetch_stripe_transactions: cache write failed: %s", exc)
+
+    return rows
+
+
 class CohortAnalysisService(BaseService):
     """Service for SaaS cohort retention, LTV, and churn computation.
 
@@ -134,7 +181,7 @@ class CohortAnalysisService(BaseService):
                 months_analyzed: int
                 total_customers: int
         """
-        rows = await self._fetch_stripe_revenue(user_id, months)
+        rows = await _fetch_stripe_transactions(months=months, user_id=user_id)
         if not rows:
             return {"cohorts": {}, "months_analyzed": months, "total_customers": 0}
 
@@ -186,7 +233,7 @@ class CohortAnalysisService(BaseService):
                 cohorts: {month: {avg_ltv, total_revenue, customer_count}}
                 overall_avg_ltv: float
         """
-        rows = await self._fetch_stripe_revenue(user_id, months)
+        rows = await _fetch_stripe_transactions(months=months, user_id=user_id)
         if not rows:
             return {"cohorts": {}, "overall_avg_ltv": 0.0}
 
@@ -242,7 +289,7 @@ class CohortAnalysisService(BaseService):
                 cohorts: {month: {churn_rate, churned, total}}
                 overall_churn_rate: float
         """
-        rows = await self._fetch_stripe_revenue(user_id, months)
+        rows = await _fetch_stripe_transactions(months=months, user_id=user_id)
         if not rows:
             return {"cohorts": {}, "overall_churn_rate": 0.0}
 

--- a/app/services/cohort_analysis_service.py
+++ b/app/services/cohort_analysis_service.py
@@ -67,7 +67,7 @@ async def _fetch_stripe_transactions(months: int, user_id: str) -> list[dict[str
     try:
         cache = get_cache_service()
         await cache.set_with_age(cache_key, rows, ttl=300)
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:
         logger.debug("_fetch_stripe_transactions: cache write failed: %s", exc)
 
     return rows

--- a/app/services/intelligence/__init__.py
+++ b/app/services/intelligence/__init__.py
@@ -4,6 +4,7 @@ Public surface:
 - score_confidence / to_band — generic weighted scorer and band classifier
 - presets — named confidence formulas per agent domain
 - write_claim / write_claims / find_claims — kg_findings writers and reader
+- search_claims_semantic — pgvector cosine-distance semantic search
 - claim_freshness_hours — graph-tier freshness check
 - get_or_create_entity — entity resolution with idempotent upsert
 - should_query_graph / should_call_external — two-tier adaptive cache
@@ -16,6 +17,7 @@ from app.services.intelligence.claims import (
     claim_freshness_hours,
     find_claims,
     get_or_create_entity,
+    search_claims_semantic,
     write_claim,
     write_claims,
 )
@@ -39,6 +41,7 @@ __all__ = [
     "get_or_create_entity",
     "presets",
     "score_confidence",
+    "search_claims_semantic",
     "should_call_external",
     "should_query_graph",
     "to_band",

--- a/app/services/intelligence/__init__.py
+++ b/app/services/intelligence/__init__.py
@@ -5,6 +5,7 @@ Public surface:
 - presets — named confidence formulas per agent domain
 - write_claim / write_claims / find_claims — kg_findings writers and reader
 - search_claims_semantic — pgvector cosine-distance semantic search
+- detect_contradictions — embedding-similarity contradiction flagger
 - claim_freshness_hours — graph-tier freshness check
 - get_or_create_entity — entity resolution with idempotent upsert
 - should_query_graph / should_call_external — two-tier adaptive cache
@@ -15,6 +16,7 @@ from app.services.intelligence import presets
 from app.services.intelligence.cache import should_call_external, should_query_graph
 from app.services.intelligence.claims import (
     claim_freshness_hours,
+    detect_contradictions,
     find_claims,
     get_or_create_entity,
     search_claims_semantic,
@@ -37,6 +39,7 @@ __all__ = [
     "ClaimSource",
     "ConfidenceBand",
     "claim_freshness_hours",
+    "detect_contradictions",
     "find_claims",
     "get_or_create_entity",
     "presets",

--- a/app/services/intelligence/claims.py
+++ b/app/services/intelligence/claims.py
@@ -515,6 +515,131 @@ async def search_claims_semantic(
     return results
 
 
+async def detect_contradictions(
+    new_claim_text: str,
+    *,
+    entity_id: UUID,
+    threshold: float = 0.85,
+) -> list[UUID]:
+    """Find existing claims about the same entity that may contradict the new one.
+
+    Strategy: embed the new claim, compare against existing claims attached
+    to the same entity via pgvector cosine distance. Return UUIDs of rows
+    whose similarity (1 - distance) >= threshold.
+
+    Degrades silently: embedding failure or DB failure returns [].
+
+    Note: this is an *embedding-similarity* signal, not semantic
+    interpretation. Two claims with similarity 0.9 are about the same
+    topic — they may agree or disagree. The flag prompts human review.
+
+    Args:
+        new_claim_text: The claim text to check for contradictions.
+        entity_id: Entity UUID to scope the comparison to.
+        threshold: Minimum cosine similarity (1 - distance) to flag.
+                   Default 0.85 — only strong topical overlaps are returned.
+
+    Returns:
+        list[UUID] of existing kg_findings rows whose similarity to
+        new_claim_text meets or exceeds the threshold.
+    """
+    if not new_claim_text or len(new_claim_text.strip()) < 20:
+        return []
+
+    embedding = await _embed_text(new_claim_text)
+    if embedding is None:
+        return []
+
+    try:
+        rows = await _contradiction_query_rows(
+            embedding=embedding,
+            entity_id=entity_id,
+        )
+    except Exception as e:
+        logger.warning("detect_contradictions query failed: %s", e)
+        return []
+
+    matches: list[UUID] = []
+    for r in rows:
+        # The ``similarity`` column from the SQL is the COSINE DISTANCE
+        # (0 = identical, 2 = opposite). Convert: similarity_score = 1 - distance.
+        # Only include rows where similarity_score >= threshold.
+        distance = float(r.get("similarity", 1.0))
+        similarity_score = 1.0 - distance
+        if similarity_score >= threshold:
+            try:
+                matches.append(UUID(r["id"]))
+            except (KeyError, ValueError):
+                continue
+    return matches
+
+
+async def _contradiction_query_rows(
+    *,
+    embedding: list[float],
+    entity_id: UUID,
+) -> list[dict]:
+    """Fetch (id, distance) pairs for existing claims on the same entity.
+
+    Uses psycopg directly for the parametrised ``<=>`` operator. Limited to
+    the top 20 nearest neighbours so we don't scan unbounded rows.
+
+    Args:
+        embedding: Query embedding vector.
+        entity_id: Entity UUID — only claims tagged to this entity are queried.
+
+    Returns:
+        List of dicts with ``id`` (str) and ``similarity`` (float cosine
+        distance). Returns [] when SUPABASE_DB_URL is not set or on any error.
+    """
+    import asyncio
+    import os
+
+    try:
+        import psycopg
+    except ImportError:
+        logger.warning(
+            "_contradiction_query_rows: psycopg not installed; returning empty results"
+        )
+        return []
+
+    dsn = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.warning(
+            "_contradiction_query_rows: SUPABASE_DB_URL not set; returning empty results"
+        )
+        return []
+
+    sql = """
+        SELECT id, (embedding <=> %s::vector) AS similarity
+          FROM kg_findings
+         WHERE entity_id = %s
+           AND embedding IS NOT NULL
+         ORDER BY embedding <=> %s::vector ASC
+         LIMIT 20
+    """
+
+    def _run() -> list[dict]:
+        """Sync psycopg call, run via executor to stay async-safe."""
+        with psycopg.connect(dsn) as conn:
+            with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                cur.execute(sql, (embedding, str(entity_id), embedding))
+                return cur.fetchall()
+
+    loop = asyncio.get_event_loop()
+    rows: list[dict] = await loop.run_in_executor(None, _run)
+    # psycopg dict_row returns real dicts; id may be UUID type — normalise
+    normalised: list[dict] = []
+    for r in rows:
+        normalised.append(
+            {
+                "id": str(r["id"]),
+                "similarity": float(r["similarity"]),
+            }
+        )
+    return normalised
+
+
 async def claim_freshness_hours(
     *,
     entity_id: UUID,

--- a/app/services/intelligence/claims.py
+++ b/app/services/intelligence/claims.py
@@ -329,6 +329,194 @@ async def find_claims(
         return []
 
 
+async def _semantic_query_rows(
+    *,
+    embedding: list[float],
+    agent_id: str | None,
+    claim_type: str | None,
+    top_k: int,
+) -> list[dict]:
+    """Execute a pgvector cosine-distance query and return raw row dicts.
+
+    Uses psycopg directly for the parametrised ``<=>`` operator which the
+    Supabase PostgREST client cannot express. The ``similarity`` key in each
+    returned dict is the cosine *distance* (0 = identical, 2 = opposite) —
+    lower values indicate higher semantic similarity.
+
+    Args:
+        embedding: Query embedding vector (must match column dimension, 768).
+        agent_id: Optional agent filter. None means all agents.
+        claim_type: Optional claim_type filter. None means all types.
+        top_k: Maximum rows returned.
+
+    Returns:
+        List of row dicts with all kg_findings columns plus ``similarity``
+        (cosine distance float). Returns [] on any DB error.
+    """
+    import asyncio
+    import os
+
+    try:
+        import psycopg
+    except ImportError:
+        logger.warning(
+            "_semantic_query_rows: psycopg not installed; returning empty results"
+        )
+        return []
+
+    db_url = os.environ.get("SUPABASE_DB_URL")
+    if not db_url:
+        logger.warning(
+            "_semantic_query_rows: SUPABASE_DB_URL not set; returning empty results"
+        )
+        return []
+
+    # Build WHERE clause fragments dynamically
+    filters: list[str] = []
+    params: list = [embedding, top_k]
+    if agent_id is not None:
+        params.insert(1, agent_id)
+        filters.append(f"agent_id = ${len(params) - 1}")
+    if claim_type is not None:
+        params.append(claim_type)
+        filters.append(f"claim_type = ${len(params)}")
+
+    # Rebuild param placeholders after all params are assembled:
+    # $1 = embedding, then any filters use $2, $3 ...
+    # top_k is the last param
+    # Re-number: embedding is always $1, top_k is always the last ($N)
+    top_k_placeholder = f"${len(params)}"
+    where_sql = ""
+    if filters:
+        where_sql = "WHERE " + " AND ".join(filters)
+
+    sql = f"""
+        SELECT
+            id, entity_id, edge_id, agent_id, claim_type, domain,
+            finding_text, confidence, sources, contradicts,
+            freshness_at, expires_at, created_at,
+            (embedding <=> $1::vector) AS similarity
+        FROM kg_findings
+        {where_sql}
+        ORDER BY embedding <=> $1::vector ASC
+        LIMIT {top_k_placeholder}
+    """  # noqa: S608 — not a user-input SQL fragment
+
+    def _run() -> list[dict]:
+        """Sync psycopg call, run via executor to stay async-safe."""
+        with psycopg.connect(db_url) as conn:
+            with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                cur.execute(sql, params)
+                return cur.fetchall()
+
+    try:
+        loop = asyncio.get_event_loop()
+        rows: list[dict] = await loop.run_in_executor(None, _run)
+        return rows
+    except Exception as e:
+        logger.warning("_semantic_query_rows DB query failed: %s", e)
+        return []
+
+
+async def search_claims_semantic(
+    *,
+    query: str,
+    agent_id: str | None = None,
+    claim_type: str | None = None,
+    top_k: int = 10,
+) -> list[tuple["Claim", float]]:
+    """Search kg_findings by semantic similarity using pgvector cosine distance.
+
+    Embeds *query* via Vertex AI, then executes an ``ORDER BY embedding <=> $1``
+    query against kg_findings. Results are returned sorted ascending by cosine
+    distance (most similar first).
+
+    Degrades silently: returns [] when the embedding service is unavailable or
+    the DB query fails — callers treat an empty result as a cache miss, not an
+    error.
+
+    Args:
+        query: Natural-language search string.
+        agent_id: Optional — restrict to a specific agent.
+        claim_type: Optional — restrict to a single claim_type.
+        top_k: Max results returned. Default 10; capped at 100.
+
+    Returns:
+        List of ``(Claim, similarity_float)`` tuples sorted by ascending cosine
+        distance (0 = identical, 2 = opposite).
+    """
+    from app.services.intelligence.schemas import Claim, ClaimSource
+
+    top_k = min(top_k, 100)
+
+    embedding = await _embed_text(query)
+    if embedding is None:
+        logger.warning(
+            "search_claims_semantic: embedding failed for query %r — returning []",
+            query[:80],
+        )
+        return []
+
+    rows = await _semantic_query_rows(
+        embedding=embedding,
+        agent_id=agent_id,
+        claim_type=claim_type,
+        top_k=top_k,
+    )
+
+    results: list[tuple[Claim, float]] = []
+    for r in rows:
+        try:
+            sources_raw = r.get("sources") or []
+            sources = [
+                ClaimSource(**s)
+                if isinstance(s, dict)
+                else ClaimSource(kind="other", ref=str(s))
+                for s in sources_raw
+            ]
+
+            def _parse_dt(val):
+                if val is None:
+                    return None
+                if isinstance(val, str):
+                    return datetime.fromisoformat(val.replace("Z", "+00:00"))
+                return val
+
+            claim = Claim(
+                id=UUID(r["id"]) if isinstance(r["id"], str) else r["id"],
+                entity_id=(
+                    UUID(r["entity_id"])
+                    if r.get("entity_id") and isinstance(r["entity_id"], str)
+                    else r.get("entity_id")
+                ),
+                edge_id=(
+                    UUID(r["edge_id"])
+                    if r.get("edge_id") and isinstance(r["edge_id"], str)
+                    else r.get("edge_id")
+                ),
+                agent_id=r["agent_id"],
+                claim_type=r["claim_type"],
+                domain=r["domain"],
+                finding_text=r["finding_text"],
+                confidence=float(r["confidence"]),
+                sources=sources,
+                contradicts=[
+                    UUID(c) if isinstance(c, str) else c
+                    for c in (r.get("contradicts") or [])
+                ],
+                freshness_at=_parse_dt(r["freshness_at"]),
+                expires_at=_parse_dt(r.get("expires_at")),
+                created_at=_parse_dt(r["created_at"]),
+            )
+            similarity = float(r["similarity"])
+            results.append((claim, similarity))
+        except Exception as e:
+            logger.warning("search_claims_semantic: failed to parse row: %s", e)
+            continue
+
+    return results
+
+
 async def claim_freshness_hours(
     *,
     entity_id: UUID,

--- a/app/services/intelligence/claims.py
+++ b/app/services/intelligence/claims.py
@@ -398,7 +398,7 @@ async def _semantic_query_rows(
         {where_sql}
         ORDER BY embedding <=> %s::vector ASC
         LIMIT %s
-    """  # noqa: S608 — not a user-input SQL fragment
+    """
 
     def _run() -> list[dict]:
         """Sync psycopg call, run via executor to stay async-safe."""
@@ -422,7 +422,7 @@ async def search_claims_semantic(
     agent_id: str | None = None,
     claim_type: str | None = None,
     top_k: int = 10,
-) -> list[tuple["Claim", float]]:
+) -> list[tuple[Claim, float]]:
     """Search kg_findings by semantic similarity using pgvector cosine distance.
 
     Embeds *query* via Vertex AI, then executes an ``ORDER BY embedding <=> $1``

--- a/app/services/intelligence/claims.py
+++ b/app/services/intelligence/claims.py
@@ -371,21 +371,19 @@ async def _semantic_query_rows(
         )
         return []
 
-    # Build WHERE clause fragments dynamically
+    # Use %s-style parameters (psycopg default) to avoid double-counting of
+    # positional placeholders ($N syntax counts each occurrence separately).
+    # embedding appears twice: once in SELECT, once in ORDER BY — pass it twice.
     filters: list[str] = []
-    params: list = [embedding, top_k]
+    params: list = [embedding, embedding]  # for SELECT + ORDER BY
     if agent_id is not None:
-        params.insert(1, agent_id)
-        filters.append(f"agent_id = ${len(params) - 1}")
+        filters.append("agent_id = %s")
+        params.append(agent_id)
     if claim_type is not None:
+        filters.append("claim_type = %s")
         params.append(claim_type)
-        filters.append(f"claim_type = ${len(params)}")
+    params.append(top_k)  # for LIMIT
 
-    # Rebuild param placeholders after all params are assembled:
-    # $1 = embedding, then any filters use $2, $3 ...
-    # top_k is the last param
-    # Re-number: embedding is always $1, top_k is always the last ($N)
-    top_k_placeholder = f"${len(params)}"
     where_sql = ""
     if filters:
         where_sql = "WHERE " + " AND ".join(filters)
@@ -395,11 +393,11 @@ async def _semantic_query_rows(
             id, entity_id, edge_id, agent_id, claim_type, domain,
             finding_text, confidence, sources, contradicts,
             freshness_at, expires_at, created_at,
-            (embedding <=> $1::vector) AS similarity
+            (embedding <=> %s::vector) AS similarity
         FROM kg_findings
         {where_sql}
-        ORDER BY embedding <=> $1::vector ASC
-        LIMIT {top_k_placeholder}
+        ORDER BY embedding <=> %s::vector ASC
+        LIMIT %s
     """  # noqa: S608 — not a user-input SQL fragment
 
     def _run() -> list[dict]:

--- a/app/services/intelligence/claims.py
+++ b/app/services/intelligence/claims.py
@@ -135,15 +135,29 @@ async def write_claim(
     client = _get_supabase_client()
 
     embedding: list[float] | None = None
+    auto_contradicts: list[UUID] = []
     if embed and finding_text and len(finding_text) >= 20:
         embedding = await _embed_text(finding_text)
+        # Auto-populate contradicts for entity-attached claims — only meaningful
+        # when we have an embedding to compare. Skip silently on any error.
+        if embedding is not None and entity_id is not None:
+            try:
+                auto_contradicts = await detect_contradictions(
+                    finding_text,
+                    entity_id=entity_id,
+                )
+            except Exception as e:
+                logger.warning("auto-detect_contradictions failed: %s", e)
+
+    # Merge caller-supplied and auto-detected contradicts, deduplicate.
+    all_contradicts: list[UUID] = list({*contradicts, *auto_contradicts})
 
     row: dict = {
         "domain": domain,
         "finding_text": finding_text,
         "confidence": confidence,
         "sources": list(sources),
-        "contradicts": [str(c) for c in contradicts],
+        "contradicts": [str(c) for c in all_contradicts],
         "agent_id": agent_id,
         "claim_type": claim_type,
     }

--- a/app/services/intelligence/presets/__init__.py
+++ b/app/services/intelligence/presets/__init__.py
@@ -5,6 +5,7 @@ input mapping and weights. Add a new preset when a new agent class needs
 its own formula — Phase 113 adds data_confidence.
 """
 
+from app.services.intelligence.presets.data import data_confidence
 from app.services.intelligence.presets.research import research_confidence
 
-__all__ = ["research_confidence"]
+__all__ = ["data_confidence", "research_confidence"]

--- a/app/services/intelligence/presets/data.py
+++ b/app/services/intelligence/presets/data.py
@@ -57,4 +57,17 @@ def data_confidence(
         0.  This models the idea that highly anomalous results are less
         trustworthy as stable trend indicators.
     """
-    raise NotImplementedError("data_confidence is not yet implemented — Task 4 pending")
+    sample_adequacy = min(1.0, sample_size / sample_threshold)
+    completeness = max(0.0, 1.0 - missing_pct)
+    statistical_strength = max(0.0, 1.0 - min(1.0, sigma_distance / 3.0))
+    recency = max(0.0, 1.0 - min(1.0, data_age_hours / recency_horizon_hours))
+
+    return score_confidence(
+        inputs={
+            "sample_adequacy": sample_adequacy,
+            "completeness": completeness,
+            "statistical_strength": statistical_strength,
+            "recency": recency,
+        },
+        weights=DATA_WEIGHTS,
+    )

--- a/app/services/intelligence/presets/data.py
+++ b/app/services/intelligence/presets/data.py
@@ -4,9 +4,9 @@ Phase 113-01 — pilots on the cohort_analysis tool in app/agents/data/tools.py.
 
 The formula weights four signals:
 - sample_adequacy  (0.35): are we working with enough rows to trust statistics?
-- completeness     (0.25): how many fields are present (1 − missing_pct)?
+- completeness     (0.25): how many fields are present (1 - missing_pct)?
 - statistical_strength (0.25): how close to expected baseline?
-                              *Inverted* — high sigma_distance means an
+                              *Inverted* -- high sigma_distance means an
                               anomalous / unstable trend, reducing confidence.
 - recency          (0.15): how fresh is the dataset?
 """

--- a/app/services/intelligence/presets/data.py
+++ b/app/services/intelligence/presets/data.py
@@ -1,0 +1,60 @@
+"""Data-domain confidence preset.
+
+Phase 113-01 — pilots on the cohort_analysis tool in app/agents/data/tools.py.
+
+The formula weights four signals:
+- sample_adequacy  (0.35): are we working with enough rows to trust statistics?
+- completeness     (0.25): how many fields are present (1 − missing_pct)?
+- statistical_strength (0.25): how close to expected baseline?
+                              *Inverted* — high sigma_distance means an
+                              anomalous / unstable trend, reducing confidence.
+- recency          (0.15): how fresh is the dataset?
+"""
+
+from __future__ import annotations
+
+from app.services.intelligence.confidence import score_confidence
+
+DATA_WEIGHTS: dict[str, float] = {
+    "sample_adequacy": 0.35,
+    "completeness": 0.25,
+    "statistical_strength": 0.25,
+    "recency": 0.15,
+}
+
+
+def data_confidence(
+    sample_size: int,
+    missing_pct: float,
+    sigma_distance: float,
+    data_age_hours: float,
+    *,
+    sample_threshold: int = 100,
+    recency_horizon_hours: float = 720,
+) -> float:
+    """Compute data-domain confidence from dataset quality signals.
+
+    Args:
+        sample_size: Number of data points / rows in the analysis.
+        missing_pct: Fraction of missing fields in [0.0, 1.0].
+        sigma_distance: Standard-deviation distance from a baseline expectation.
+            High values (> 3) indicate anomalous / outlier data, which *lowers*
+            confidence in trend stability (inverted signal — see note below).
+            Pass 0.0 when no baseline is available (known TODO: wire a real
+            baseline from CohortAnalysisService once it surfaces one).
+        data_age_hours: Age of the freshest record in the dataset in hours.
+        sample_threshold: Minimum sample size considered adequate (default 100).
+        recency_horizon_hours: Age at which recency score reaches zero (default
+            720 h = 30 days).
+
+    Returns:
+        Confidence score clamped to [0.0, 1.0].
+
+    Note — sigma inversion:
+        ``statistical_strength = 1 - sigma_distance / 3`` is intentionally
+        *inverted*: a sigma_distance of 0 means the data is right at the
+        expected baseline (high confidence), while a distance ≥ 3 saturates to
+        0.  This models the idea that highly anomalous results are less
+        trustworthy as stable trend indicators.
+    """
+    raise NotImplementedError("data_confidence is not yet implemented — Task 4 pending")

--- a/docs/intelligence/claim-types.md
+++ b/docs/intelligence/claim-types.md
@@ -1,0 +1,38 @@
+# Claim-type vocabulary
+
+The `claim_type` column on `kg_findings` is a free-text discriminator
+used by `find_claims`, `should_query_graph`, and (in 113-04)
+`search_claims_semantic`. Consistent vocabulary across agents lets
+the Executive query "any claim of type X" without per-agent guessing.
+
+## Data Agent (Plan 113-03)
+
+| `claim_type` | What it represents | When emitted |
+|---|---|---|
+| `cohort_summary` | Single high-level finding per `cohort_analysis` call. Powers Plan 113-02's graph-tier short-circuit. | One per `cohort_analysis(months)` call. |
+| `cohort_retention_m1` ... `cohort_retention_m6` | Per-month retention rate within a cohort. One claim per (cohort, month) pair. | Multiple per `cohort_analysis` call — one per (cohort, month_offset) in the retention curve. |
+
+Reserved for future Data Agent plans (not emitted yet):
+
+| `claim_type` | What it represents | When emitted |
+|---|---|---|
+| `weekly_insight` | A single insight from `generate_weekly_report`. | Future Data Agent plan. |
+| `kpi_anomaly` | An anomaly detected against a baseline. | Future Data Agent plan. |
+| `revenue_trend` | Direction assertion ("revenue trending up Q1"). | Future Data Agent plan. |
+
+## Research Agent
+
+| `claim_type` | What it represents |
+|---|---|
+| `research_finding` | A finding emitted by the Research Agent's multi-track synthesis. The legacy default for pre-Plan-112-01 rows. |
+
+## How to add a new claim_type
+
+1. Pick a snake_case name that describes the *epistemic content* (not the
+   workflow that produced it). Prefer "what's claimed" over "how it was
+   measured" — e.g., `cohort_retention_m3` not `stripe_query_result_3`.
+2. Add it to the table above with: what it represents, when emitted.
+3. If the claim's writer is a new agent, document the agent_id naming
+   too (lowercase, matches the agent_id column in kg_findings).
+4. Run `find_claims(claim_type="<new_name>")` after the first emission
+   to confirm it lands.

--- a/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-01-data-confidence-preset.md
+++ b/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-01-data-confidence-preset.md
@@ -1,0 +1,665 @@
+# Shared Intelligence Infrastructure — Plan 113-01: Data Confidence Preset + Pilot Wiring
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `app/services/intelligence/presets/data.py` with `data_confidence(sample_size, missing_pct, sigma_distance, data_age_hours)` and wire it into Data Agent's `cohort_analysis` as the pilot adoption. Other Data Agent tools (`query_analytics`, `query_usage`, `generate_weekly_report`) adopt in Plans 113-02 / 113-03 alongside the cache and claim-emission work.
+
+**Architecture:** Pure-function preset using the existing generic `score_confidence` from Plan 112-02. The formula codifies Data Agent's statistical rigor (already documented in `app/agents/data/agent.py:166-176` — sample_size ≥ 30 trends, ≥ 100 anomalies, missing >20% flagged, outliers >3σ). The pilot wiring computes the four signals from real cohort data and adds `confidence` + `band` fields to the `cohort_analysis` response payload.
+
+**Tech Stack:** Python 3.10+ (already configured), Pydantic v2 (for `to_band`), the shared `app/services/intelligence/` package.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-18-shared-intelligence-infra-design.md` § Module specifications § presets/data.py + § Phase 113
+
+**Out of scope for this plan:** Two-tier cache wiring around Stripe calls (Plan 113-02), claim emission to `kg_findings` from cohort results (Plan 113-03), pgvector-backed semantic search (Plan 113-04), contradiction detection (Plan 113-05), other Data Agent functions beyond `cohort_analysis`.
+
+---
+
+## File structure
+
+**Create:**
+- `app/services/intelligence/presets/data.py` — `data_confidence` and `DATA_WEIGHTS`
+- `tests/unit/services/intelligence/test_presets_data.py` — preset unit tests
+
+**Modify:**
+- `app/services/intelligence/presets/__init__.py` — re-export `data_confidence`
+- `app/services/intelligence/__init__.py` — no change needed (presets is already in `__all__`)
+- `app/agents/data/tools.py:220-265` — `cohort_analysis` adds confidence + band to response
+- Existing cohort-analysis tests if any (find via grep before modifying)
+
+**Reference (read-only):**
+- `app/services/intelligence/confidence.py` — `score_confidence` and `to_band`
+- `app/services/intelligence/presets/research.py` — pattern to mirror
+- `app/services/cohort_analysis_service.py` — `CohortAnalysisService` returns the raw data shape that `cohort_analysis` uses
+- `app/agents/data/agent.py:166-176` — statistical rigor expectations baked into agent instructions
+
+---
+
+## Pre-flight context
+
+Existing Data Agent statistical rigor (from `app/agents/data/agent.py:166-176`):
+- Minimum sample sizes: **30 for trends, 100 for anomalies**
+- Flag missing values **>20%**, don't analyze if **>50% missing**
+- Flag outliers **>3 std dev**
+- Always report confidence intervals on forecasts
+- Distinguish correlation from causation explicitly
+
+`data_confidence` formula (from the spec):
+```python
+DATA_WEIGHTS = {
+    "sample_adequacy": 0.35,
+    "completeness": 0.25,
+    "statistical_strength": 0.25,
+    "recency": 0.15,
+}
+
+sample_adequacy      = min(1.0, sample_size / sample_threshold)       # threshold=100 default
+completeness         = max(0.0, 1.0 - missing_pct)
+statistical_strength = max(0.0, 1.0 - min(1.0, sigma_distance / 3.0)) # inversion: high sigma = anomalous, low confidence in stability
+recency              = max(0.0, 1.0 - min(1.0, data_age_hours / recency_horizon_hours))  # horizon=720h=30d default
+```
+
+**`statistical_strength` inverts sigma deliberately** — high sigma means *anomalous*, not *certain*. An anomaly detection has high signal but low confidence in trend stability.
+
+`cohort_analysis(months: int = 6)` is at `app/agents/data/tools.py:220`. It delegates to `app/services/cohort_analysis_service.py:CohortAnalysisService`. The pilot needs to:
+1. Extract signals from the service's result
+2. Compute `data_confidence(...)`
+3. Add `confidence` and `band` to the response dict
+
+Environment quirks (carried from Phase 112):
+- `uv` only via PowerShell
+- Test env vars for tests that hit external services: `SUPABASE_*`, `REDIS_*`
+- `pytest-asyncio` is installed and `asyncio_mode = "strict"` is set
+
+---
+
+## Tasks
+
+### Task 1: Pre-flight — confirm Phase 112 is integrated and locate cohort_analysis
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Confirm Phase 112 is integrated**
+
+```bash
+ls app/services/intelligence/{__init__,confidence,claims,cache,schemas}.py app/services/intelligence/presets/{__init__,research}.py
+grep -E "^def (score_confidence|to_band)" app/services/intelligence/confidence.py
+grep -E "^def research_confidence" app/services/intelligence/presets/research.py
+```
+
+Expected: all files exist, all three functions present (not stubs). If any missing, Phase 112 isn't integrated locally — `git log --oneline | grep 112` should show ~32 commits.
+
+- [ ] **Step 2: Confirm `cohort_analysis` and `CohortAnalysisService` shapes**
+
+```bash
+grep -n "def cohort_analysis\|class CohortAnalysisService\|def analyze" app/agents/data/tools.py app/services/cohort_analysis_service.py | head -10
+```
+
+Read the service's `analyze` method (or equivalent) to understand the result dict shape — specifically, what fields are available to compute `sample_size`, `missing_pct`, `sigma_distance`, `data_age_hours`. Most likely:
+- `sample_size` = total customers / orders / records in the analysis window
+- `missing_pct` = rows with NULL key fields / total rows (often near 0 for Stripe-derived data)
+- `sigma_distance` = how far retention is from the historical mean (may need to compute, or default to 0 if no historical baseline)
+- `data_age_hours` = time since the latest record in the cohort
+
+Capture the result shape for the implementation in Task 4.
+
+No commit in this task.
+
+### Task 2: Scaffold `presets/data.py` with stub
+
+**Files:**
+- Create: `app/services/intelligence/presets/data.py`
+
+- [ ] **Step 1: Create the file with stub**
+
+```python
+"""Data-domain confidence preset.
+
+Used by Data Agent tools (cohort_analysis, query_analytics, ...) to
+attach a calibrated confidence band to numerical / statistical outputs.
+
+Formula reflects the statistical rigor already documented in
+app/agents/data/agent.py:166-176 (sample_size >= 30 trends / >= 100
+anomalies, missing >20% flagged, outliers >3 sigma).
+"""
+
+from __future__ import annotations
+
+
+def data_confidence(
+    sample_size: int,
+    missing_pct: float,
+    sigma_distance: float,
+    data_age_hours: float,
+    *,
+    sample_threshold: int = 100,
+    recency_horizon_hours: float = 720,  # 30 days
+) -> float:
+    """Stub — implemented in Task 4. Do not call yet."""
+    raise NotImplementedError("Implemented in Plan 113-01 Task 4")
+```
+
+- [ ] **Step 2: Update `presets/__init__.py` to re-export the stub**
+
+Edit `app/services/intelligence/presets/__init__.py`. Add the import alongside `research_confidence`:
+
+```python
+"""Per-agent confidence presets."""
+
+from app.services.intelligence.presets.data import data_confidence
+from app.services.intelligence.presets.research import research_confidence
+
+__all__ = ["data_confidence", "research_confidence"]
+```
+
+- [ ] **Step 3: Verify imports**
+
+```powershell
+uv run python -c "from app.services.intelligence.presets import data_confidence, research_confidence; print('preset imports OK')"
+```
+
+Expected: `preset imports OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/services/intelligence/presets/data.py app/services/intelligence/presets/__init__.py
+git commit -m "feat(113-01): scaffold data_confidence preset (stub)"
+```
+
+### Task 3: Write failing unit tests for `data_confidence`
+
+**Files:**
+- Create: `tests/unit/services/intelligence/test_presets_data.py`
+
+- [ ] **Step 1: Create the test file**
+
+```python
+"""Unit tests for app.services.intelligence.presets.data."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services.intelligence.presets.data import data_confidence
+
+
+# ---------------------------------------------------------------------------
+# Boundary cases — sample size dominates at low N
+# ---------------------------------------------------------------------------
+
+
+def test_zero_sample_returns_low_confidence():
+    """sample_size=0 nukes sample_adequacy (weight 0.35); result <= 0.65."""
+    result = data_confidence(
+        sample_size=0, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    # Other inputs perfect: completeness=1.0 (0.25), strength=1.0 (0.25),
+    # recency=1.0 (0.15). Sample at 0 contributes 0. Total = 0.65.
+    assert math.isclose(result, 0.65, abs_tol=1e-9)
+
+
+def test_full_sample_high_confidence():
+    """sample_size=100, missing=0, sigma=0, age=0 -> 1.0."""
+    result = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+
+
+def test_oversized_sample_clamped_at_threshold():
+    """sample_size > sample_threshold (default 100) doesn't help beyond 1.0."""
+    result_100 = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    result_10000 = data_confidence(
+        sample_size=10000, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    assert math.isclose(result_100, result_10000, abs_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# missing_pct
+# ---------------------------------------------------------------------------
+
+
+def test_missing_data_reduces_confidence():
+    """50% missing data reduces completeness contribution by half."""
+    full = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    half_missing = data_confidence(
+        sample_size=100, missing_pct=0.5, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    # completeness contribution drops from 0.25 to 0.125, total drops by 0.125
+    assert math.isclose(full - half_missing, 0.125, abs_tol=1e-9)
+
+
+def test_complete_data_missing():
+    """missing_pct=1.0 zeros out the completeness contribution (-0.25)."""
+    result = data_confidence(
+        sample_size=100, missing_pct=1.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    # sample=1.0*0.35 + completeness=0.0*0.25 + strength=1.0*0.25 + recency=1.0*0.15 = 0.75
+    assert math.isclose(result, 0.75, abs_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# sigma_distance — high sigma INVERTS to LOW confidence in stability
+# ---------------------------------------------------------------------------
+
+
+def test_zero_sigma_full_statistical_strength():
+    """sigma=0 means data is at the mean — full statistical strength."""
+    result = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+
+
+def test_three_sigma_zeros_statistical_strength():
+    """sigma >= 3.0 saturates the inversion — strength contribution drops to 0."""
+    result = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=3.0, data_age_hours=0.0,
+    )
+    # sample=0.35 + completeness=0.25 + strength=0 + recency=0.15 = 0.75
+    assert math.isclose(result, 0.75, abs_tol=1e-9)
+
+
+def test_high_sigma_floored_at_zero_strength():
+    """sigma >> 3.0 doesn't make confidence negative — strength floored at 0."""
+    result_3 = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=3.0, data_age_hours=0.0,
+    )
+    result_10 = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=10.0, data_age_hours=0.0,
+    )
+    assert math.isclose(result_3, result_10, abs_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# data_age_hours — older data discounts recency
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_data_full_recency():
+    """age=0 contributes full recency weight."""
+    result = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+
+
+def test_30_day_old_data_zeros_recency():
+    """age >= default horizon (720h) saturates the decay."""
+    result = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=720.0,
+    )
+    # sample=0.35 + completeness=0.25 + strength=0.25 + recency=0 = 0.85
+    assert math.isclose(result, 0.85, abs_tol=1e-9)
+
+
+def test_ancient_data_floored_at_zero_recency():
+    """age >> horizon doesn't make confidence negative."""
+    result_720 = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=720.0,
+    )
+    result_1y = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=8760.0,
+    )
+    assert math.isclose(result_720, result_1y, abs_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Configurable thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_custom_sample_threshold():
+    """sample_threshold override changes what counts as 'fully sampled'."""
+    # With threshold=30 (trends spec), sample=30 hits adequacy=1.0
+    result = data_confidence(
+        sample_size=30, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+        sample_threshold=30,
+    )
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+
+
+def test_custom_recency_horizon():
+    """recency_horizon override changes what counts as 'old'."""
+    # With horizon=24h, age=24h saturates the decay
+    result = data_confidence(
+        sample_size=100, missing_pct=0.0, sigma_distance=0.0, data_age_hours=24.0,
+        recency_horizon_hours=24.0,
+    )
+    assert math.isclose(result, 0.85, abs_tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Result is always in [0.0, 1.0]
+# ---------------------------------------------------------------------------
+
+
+def test_all_worst_case_returns_zero():
+    """All inputs at their worst saturate to floor (still non-negative)."""
+    result = data_confidence(
+        sample_size=0, missing_pct=1.0, sigma_distance=10.0, data_age_hours=10000.0,
+    )
+    assert result == 0.0
+
+
+def test_all_best_case_returns_one():
+    """All inputs at their best -> 1.0."""
+    result = data_confidence(
+        sample_size=1000, missing_pct=0.0, sigma_distance=0.0, data_age_hours=0.0,
+    )
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+```
+
+- [ ] **Step 2: Run — should FAIL with NotImplementedError**
+
+```powershell
+uv run pytest tests/unit/services/intelligence/test_presets_data.py -v --tb=short
+```
+
+Expected: 15 FAILED with NotImplementedError.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/services/intelligence/test_presets_data.py
+git commit -m "test(113-01): failing unit tests for data_confidence preset"
+```
+
+### Task 4: Implement `data_confidence` (GREEN)
+
+**Files:**
+- Modify: `app/services/intelligence/presets/data.py`
+
+- [ ] **Step 1: Replace the stub with the implementation**
+
+```python
+"""Data-domain confidence preset.
+
+Used by Data Agent tools (cohort_analysis, query_analytics, ...) to
+attach a calibrated confidence band to numerical / statistical outputs.
+
+Formula reflects the statistical rigor already documented in
+app/agents/data/agent.py:166-176 (sample_size >= 30 trends / >= 100
+anomalies, missing >20% flagged, outliers >3 sigma).
+"""
+
+from __future__ import annotations
+
+from app.services.intelligence.confidence import score_confidence
+
+DATA_WEIGHTS = {
+    "sample_adequacy": 0.35,
+    "completeness": 0.25,
+    "statistical_strength": 0.25,
+    "recency": 0.15,
+}
+
+
+def data_confidence(
+    sample_size: int,
+    missing_pct: float,
+    sigma_distance: float,
+    data_age_hours: float,
+    *,
+    sample_threshold: int = 100,
+    recency_horizon_hours: float = 720,  # 30 days
+) -> float:
+    """Compute confidence from internal-data statistical signals.
+
+    Args:
+        sample_size: Number of records in the analysis. Saturates at
+            sample_threshold (default 100, matching the anomaly bar).
+        missing_pct: Fraction of records with missing key fields,
+            in [0.0, 1.0]. Higher means worse completeness.
+        sigma_distance: Distance from baseline mean in standard
+            deviations. **High sigma = anomalous = LOWER confidence in
+            trend stability.** Saturates at 3.0.
+        data_age_hours: Age of the underlying data in hours. Saturates
+            at recency_horizon_hours (default 720h = 30 days).
+        sample_threshold: Custom sample-size threshold. Set to 30 for
+            trend confidence (matching the trends spec).
+        recency_horizon_hours: Custom recency decay horizon.
+
+    Returns:
+        Confidence in [0.0, 1.0].
+    """
+    sample_adequacy = min(1.0, sample_size / sample_threshold)
+    completeness = max(0.0, 1.0 - missing_pct)
+    statistical_strength = max(0.0, 1.0 - min(1.0, sigma_distance / 3.0))
+    recency = max(0.0, 1.0 - min(1.0, data_age_hours / recency_horizon_hours))
+
+    return score_confidence(
+        inputs={
+            "sample_adequacy": sample_adequacy,
+            "completeness": completeness,
+            "statistical_strength": statistical_strength,
+            "recency": recency,
+        },
+        weights=DATA_WEIGHTS,
+    )
+```
+
+- [ ] **Step 2: Run — should PASS**
+
+```powershell
+uv run pytest tests/unit/services/intelligence/test_presets_data.py -v --tb=short
+```
+
+Expected: 15 PASSED. If any fail, the formula has a typo or the test expectations are wrong — investigate the specific failure.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/services/intelligence/presets/data.py
+git commit -m "feat(113-01): implement data_confidence preset (GREEN)"
+```
+
+### Task 5: Wire `data_confidence` into `cohort_analysis`
+
+**Files:**
+- Modify: `app/agents/data/tools.py:220-265` — `cohort_analysis` function
+
+- [ ] **Step 1: Read the current implementation** of `cohort_analysis` end-to-end
+
+```bash
+grep -n "def cohort_analysis" app/agents/data/tools.py
+```
+
+Then read ~50 lines from there. Note:
+- What `CohortAnalysisService.analyze(...)` returns (the result dict shape)
+- Which fields naturally map to `sample_size`, `missing_pct`, `sigma_distance`, `data_age_hours`
+
+If `sigma_distance` isn't available from the service (the historical baseline may not exist yet), default it to `0.0` and add a TODO comment. Phase 113-03 (claim emission) will refine this.
+
+- [ ] **Step 2: Modify `cohort_analysis` to compute the four signals and call `data_confidence`**
+
+After the existing service call, before the return:
+
+```python
+# Compute confidence signals from the analysis result.
+from app.services.intelligence import to_band
+from app.services.intelligence.presets import data_confidence
+
+retention_data = result.get("retention_data", {})
+ltv_breakdown = result.get("ltv_breakdown", {})
+
+# sample_size: total customers across all cohorts (proxy for analysis robustness)
+sample_size = sum(
+    int(cohort.get("cohort_size", 0))
+    for cohort in retention_data.get("cohorts", [])
+) if isinstance(retention_data, dict) else 0
+
+# missing_pct: not directly available from CohortAnalysisService; assume
+# 0 unless the service surfaces it later. Stripe-derived data is usually
+# complete on the fields we need (signup_date, payment_count).
+missing_pct = float(result.get("missing_data_pct", 0.0))
+
+# sigma_distance: historical baseline not yet implemented in CohortAnalysisService.
+# Default to 0 (trend stability is unknown, treated as "in line with baseline").
+# Plan 113-03+ can introduce a baseline service and feed real sigma here.
+sigma_distance = float(result.get("sigma_distance", 0.0))
+
+# data_age_hours: time since the latest record. Use 1h as a conservative
+# default if the service doesn't surface a freshness timestamp.
+data_age_hours = float(result.get("data_age_hours", 1.0))
+
+confidence = data_confidence(
+    sample_size=sample_size,
+    missing_pct=missing_pct,
+    sigma_distance=sigma_distance,
+    data_age_hours=data_age_hours,
+)
+
+result["confidence"] = confidence
+result["band"] = to_band(confidence)
+```
+
+The exact field extractions depend on what `CohortAnalysisService` returns — adjust the keys based on Task 1 findings. If the service does NOT surface `missing_data_pct`, `sigma_distance`, or `data_age_hours`, the conservative defaults (0.0 missing, 0.0 sigma, 1.0h age) keep the confidence high for well-formed Stripe data and don't break existing callers.
+
+- [ ] **Step 3: Update or add a test for `cohort_analysis` confidence output**
+
+Find existing tests:
+```bash
+grep -rn "cohort_analysis\|CohortAnalysisService" tests/ | head
+```
+
+If a test for `cohort_analysis` exists, add an assertion for the new `confidence` and `band` fields. If no test exists, add a minimal one:
+
+`tests/unit/agents/data/test_cohort_analysis_confidence.py`:
+
+```python
+"""Confirm cohort_analysis attaches confidence + band fields (Plan 113-01)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_attaches_confidence_and_band():
+    """cohort_analysis result includes confidence (float) and band (literal)."""
+    from app.agents.data.tools import cohort_analysis
+
+    fake_result = {
+        "retention_data": {
+            "cohorts": [
+                {"cohort_month": "2026-01", "cohort_size": 150},
+                {"cohort_month": "2026-02", "cohort_size": 120},
+            ],
+        },
+        "ltv_breakdown": {},
+        "executive_summary": "Stable retention.",
+        "chart_data": {},
+    }
+
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+    ) as fake_service_class:
+        fake_service = fake_service_class.return_value
+        fake_service.analyze = AsyncMock(return_value=fake_result)
+        result = await cohort_analysis(months=6)
+
+    assert "confidence" in result
+    assert "band" in result
+    assert isinstance(result["confidence"], float)
+    assert 0.0 <= result["confidence"] <= 1.0
+    assert result["band"] in ("low", "medium", "high")
+    # 270 customers, default missing/sigma/age — should be high
+    assert result["band"] == "high"
+```
+
+If `CohortAnalysisService` is instantiated differently (singleton, factory), adapt the mocking — the goal is to control the return shape so the confidence wiring is the only thing under test.
+
+- [ ] **Step 4: Run the new test**
+
+```powershell
+$env:SUPABASE_URL = "http://127.0.0.1:54321"
+$env:SUPABASE_SERVICE_ROLE_KEY = (supabase status -o env | Select-String '^SERVICE_ROLE_KEY=').ToString().Split('=',2)[1].Trim('"')
+uv run pytest tests/unit/agents/data/test_cohort_analysis_confidence.py -v --tb=short
+```
+
+Expected: PASS. If the mock's patch path doesn't intercept (e.g., the actual import path differs), update the patch target.
+
+- [ ] **Step 5: Confirm no Data Agent regressions**
+
+```powershell
+uv run pytest tests/unit/agents/data/ tests/unit/test_data_*.py -v --tb=short 2>&1 | Select-Object -Last 15
+```
+
+Expected: existing tests pass; the new test passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/agents/data/tools.py tests/unit/agents/data/test_cohort_analysis_confidence.py
+git commit -m "feat(113-01): wire data_confidence into cohort_analysis pilot (GREEN)"
+```
+
+### Task 6: Lint + acceptance sign-off
+
+- [ ] **Step 1: Lint**
+
+```powershell
+uv run ruff check app/services/intelligence/presets/data.py app/agents/data/tools.py tests/unit/services/intelligence/test_presets_data.py tests/unit/agents/data/test_cohort_analysis_confidence.py
+uv run ruff format app/services/intelligence/presets/data.py app/agents/data/tools.py tests/unit/services/intelligence/test_presets_data.py tests/unit/agents/data/test_cohort_analysis_confidence.py --check
+```
+
+Expected: all clean. Fix in-place if any errors.
+
+- [ ] **Step 2: Final test run**
+
+```powershell
+uv run pytest tests/unit/services/intelligence/ tests/unit/agents/data/test_cohort_analysis_confidence.py -v --tb=short
+```
+
+Expected: all PASS — 17 from confidence module (pre-existing) + 15 from data preset + the cohort_analysis confidence test.
+
+- [ ] **Step 3: Acceptance check against spec**
+
+| Spec line | Status |
+|---|---|
+| `data_confidence(sample_size, missing_pct, sigma_distance, data_age_hours) -> float` | ✓ Task 4 |
+| Weights match spec (0.35 sample, 0.25 completeness, 0.25 strength, 0.15 recency) | ✓ Task 4 + tests |
+| `statistical_strength = 1 - sigma/3` inversion preserved | ✓ Task 4 + `test_three_sigma_zeros_statistical_strength` |
+| `sample_threshold` / `recency_horizon_hours` configurable | ✓ Task 4 + custom-threshold tests |
+| Output clamped to `[0, 1]` | ✓ via `score_confidence` |
+| Pilot integration: `cohort_analysis` carries confidence + band | ✓ Task 5 |
+| Existing Data Agent test suite green | ✓ Task 5 Step 5 |
+| No new ADK tools | ✓ Library only |
+
+- [ ] **Step 4: Commit any lint fixes**
+
+```bash
+git add app/services/intelligence/presets/data.py app/agents/data/tools.py tests/unit/services/intelligence/test_presets_data.py tests/unit/agents/data/test_cohort_analysis_confidence.py
+git commit -m "style(113-01): lint and format fixes for data preset and cohort wiring"
+```
+
+Skip if no fixes needed.
+
+- [ ] **Step 5: Plan 113-01 complete. Plan 113-02 (Data Agent cache integration) is unblocked.**
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task(s) |
+|---|---|
+| `data_confidence` preset with 4-signal formula | Tasks 2, 3, 4 |
+| Configurable `sample_threshold` and `recency_horizon_hours` | Task 4 + custom-threshold tests |
+| `statistical_strength` inverts sigma (anomalous = uncertain) | Task 4 + `test_three_sigma_zeros_statistical_strength` |
+| Wired into Data Agent's `cohort_analysis` | Task 5 |
+| Response payload carries `confidence` + `band` | Task 5 + `test_cohort_analysis_attaches_confidence_and_band` |
+| Existing Data Agent tests stay green | Task 5 Step 5 |
+| Public surface importable from `app.services.intelligence.presets` | Task 2 |
+| Lint clean | Task 6 |
+
+All spec lines covered. No placeholders. No unmapped requirements.

--- a/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-02-data-cache-integration.md
+++ b/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-02-data-cache-integration.md
@@ -1,0 +1,507 @@
+# Shared Intelligence Infrastructure — Plan 113-02: Data Agent Two-Tier Cache Integration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the two-tier adaptive cache (built in Plan 112-04) around Data Agent's external calls and aggregations. `should_query_graph` short-circuits `cohort_analysis` when a fresh claim exists; `should_call_external` caches Stripe API responses in Redis so a repeated query doesn't re-call Stripe. Acceptance includes a measurable Stripe-call-reduction target.
+
+**Architecture:** Two surgical wirings in `app/agents/data/tools.py:cohort_analysis`:
+1. **Graph tier (before computation):** call `should_query_graph` with the cohort entity + `claim_type="cohort_summary"`. If `verdict="fresh"`, fetch the stored Claim via `find_claims` and return immediately — no Stripe call, no recomputation.
+2. **Redis tier (before Stripe call):** wrap the Stripe transaction fetch with `should_call_external` keyed on cohort + month range. If `verdict="fresh"`, use the cached raw response. Otherwise call Stripe and `set_with_age` the response.
+
+Claim *writing* on the graph tier is deferred to Plan 113-03 (which decides the full claim-emission vocabulary). This plan only consumes existing claims; writes happen after 113-03 ships.
+
+**Tech Stack:** Plan 112-04's `should_query_graph` / `should_call_external` / `CacheService.get_with_age` / `set_with_age`. No new dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-18-shared-intelligence-infra-design.md` § Phase 113 § Cache effectiveness
+
+**Out of scope for this plan:** Writing new claims (Plan 113-03), `search_claims_semantic` (Plan 113-04), contradiction detection (Plan 113-05), wiring cache around other Data Agent functions besides `cohort_analysis` (deferred per the pilot scope locked in Plan 113-01).
+
+---
+
+## File structure
+
+**Create:**
+- `tests/integration/test_data_cache_integration.py` — round-trip tests against real Supabase + Redis
+
+**Modify:**
+- `app/agents/data/tools.py:cohort_analysis` — graph-cache short-circuit + Redis caching of Stripe payload
+- Possibly `app/services/cohort_analysis_service.py` — if Stripe access is encapsulated there, wire the Redis cache at the lowest layer to minimize blast radius
+
+**Reference (read-only):**
+- `app/services/intelligence/cache.py` — `should_query_graph`, `should_call_external`, `CacheDecision`
+- `app/services/intelligence/claims.py` — `find_claims`, `get_or_create_entity` (no `write_claim` calls in this plan)
+- Plan 113-01's pilot wiring (already in `cohort_analysis`)
+
+---
+
+## Pre-flight context
+
+The pilot wiring from Plan 113-01 added `confidence` and `band` fields to `cohort_analysis` output but did NOT cache anything yet. This plan adds the cache discipline.
+
+Cache key conventions:
+- **Graph tier:** entity = `cohort_<period>` (e.g., `cohort_2026-q1`), entity_type = `metric`, claim_type = `cohort_summary`, agent_id = `data`. Freshness threshold: **24 hours** (cohort data doesn't change frequently for past months).
+- **Redis tier:** cache key = `stripe:cohort_raw:{months}:{user_id}`. TTL: **300 seconds** (5 minutes) — Stripe transaction data is append-only so short TTL is appropriate for the recent window.
+
+Acceptance bar (from spec):
+- Stripe API call rate during synthetic 1000-request load test reduced by **≥40%** vs pre-113 baseline
+- Graph-tier hit rate for `cohort_analysis` repeated calls within 24h: **≥60%**
+
+The 40% target is generous: a repeated identical call within 5 minutes should be a 100% Redis hit. A call within 24h on the same cohort should be a 100% graph hit (once Plan 113-03 ships claim writes). For Plan 113-02, the graph tier will mostly miss because we haven't started writing claims yet — the cache acceptance is mostly about the Redis tier and the *structure* being correct so 113-03's writes start delivering hits.
+
+Environment quirks: same as 112-04 — env vars `SUPABASE_*` + `REDIS_*` (password `pikar_dev_redis`).
+
+---
+
+## Tasks
+
+### Task 1: Pre-flight + locate Stripe access point
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Confirm Plan 112-04 and Plan 113-01 are integrated**
+
+```bash
+grep -E "^async def (should_query_graph|should_call_external)" app/services/intelligence/cache.py
+grep -E "^def data_confidence" app/services/intelligence/presets/data.py
+grep -nB 2 "data_confidence" app/agents/data/tools.py
+```
+
+Expected: all three present, `data_confidence` called somewhere inside `cohort_analysis`. If `cohort_analysis` doesn't reference `data_confidence`, Plan 113-01 isn't done — finish that first.
+
+- [ ] **Step 2: Trace the Stripe call**
+
+```bash
+grep -n "stripe\|Stripe\|StripeService\|stripe_client" app/services/cohort_analysis_service.py app/agents/data/tools.py | head -20
+```
+
+Locate where `CohortAnalysisService.analyze` actually calls Stripe. Capture:
+- The function name (e.g., `_fetch_stripe_transactions`)
+- The arguments it takes (probably `start_date`, `end_date`, `user_id`)
+- The shape of its return value (list of dicts? `StripeChargeList`?)
+
+This is the function we'll wrap with `should_call_external` + `set_with_age` in Task 4. If the Stripe call is buried deep, prefer wrapping at the lowest sensible layer — the goal is to cache the raw response BEFORE any parsing.
+
+- [ ] **Step 3: Capture pre-wiring behavior as a baseline**
+
+```bash
+grep -c "stripe" app/services/cohort_analysis_service.py
+```
+
+Record the answer. After Plan 113-02 ships, the same grep should show one *additional* line (the cache check) — a sanity hint that the wiring landed where expected.
+
+No commit in this task.
+
+### Task 2: Wire graph-tier short-circuit into `cohort_analysis` (TDD)
+
+**Files:**
+- Modify: `app/agents/data/tools.py:cohort_analysis`
+- Create: `tests/integration/test_data_cache_integration.py` (first section)
+
+- [ ] **Step 1: Create the integration test file with the graph-tier tests**
+
+```python
+"""Integration tests for Data Agent two-tier cache wiring (Plan 113-02)."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="Supabase credentials not provided in environment variables.",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Graph-tier short-circuit: when a fresh claim exists, skip computation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_short_circuits_on_fresh_graph_claim():
+    """If a fresh kg_findings claim exists for the cohort, cohort_analysis
+    returns from it without invoking CohortAnalysisService.
+    """
+    from app.agents.data.tools import cohort_analysis
+    from app.services.intelligence import (
+        get_or_create_entity, write_claim,
+    )
+
+    # Seed a fresh claim
+    entity_id = await get_or_create_entity(
+        canonical_name=f"cohort_test_{uuid4()}",
+        entity_type="metric",
+        domains=["data"],
+    )
+    await write_claim(
+        entity_id=entity_id, domain="data",
+        finding_text="seeded cohort summary for short-circuit test",
+        confidence=0.85,
+        sources=[{"kind": "stripe_row", "ref": "test"}],
+        agent_id="data", claim_type="cohort_summary",
+    )
+
+    # Mock CohortAnalysisService to detect whether it was called
+    fake_service = AsyncMock()
+    fake_service.analyze = AsyncMock(return_value={})
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ), patch(
+        # The cohort_analysis function builds the entity name from `months`;
+        # patch the entity-id derivation so it lands on our seeded entity.
+        "app.agents.data.tools._cohort_entity_id",
+        AsyncMock(return_value=entity_id),
+    ):
+        result = await cohort_analysis(months=6)
+
+    # Service should NOT have been called — we returned from cache
+    fake_service.analyze.assert_not_called()
+    # Result includes the cached payload signals
+    assert "from_cache" in result and result["from_cache"] is True
+    assert result.get("band") == "high"
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_misses_graph_then_computes():
+    """Without a fresh claim, cohort_analysis calls the service normally."""
+    from app.agents.data.tools import cohort_analysis
+
+    fake_service = AsyncMock()
+    fake_service.analyze = AsyncMock(return_value={
+        "retention_data": {"cohorts": [{"cohort_size": 150}]},
+        "ltv_breakdown": {}, "executive_summary": "ok", "chart_data": {},
+    })
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ):
+        result = await cohort_analysis(months=6)
+
+    fake_service.analyze.assert_called_once()
+    assert "confidence" in result
+    assert result.get("from_cache", False) is False
+```
+
+- [ ] **Step 2: Run — should FAIL** (the helper `_cohort_entity_id` and the `from_cache` field don't exist yet)
+
+```powershell
+$env:SUPABASE_URL = "http://127.0.0.1:54321"
+$env:SUPABASE_SERVICE_ROLE_KEY = (supabase status -o env | Select-String '^SERVICE_ROLE_KEY=').ToString().Split('=',2)[1].Trim('"')
+$env:SUPABASE_DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+$env:REDIS_HOST = "localhost"; $env:REDIS_PORT = "6379"; $env:REDIS_PASSWORD = "pikar_dev_redis"
+uv run pytest tests/integration/test_data_cache_integration.py -k "graph" -v --tb=short
+```
+
+Expected: 2 FAILED.
+
+- [ ] **Step 3: Modify `cohort_analysis` to short-circuit on a fresh graph claim**
+
+Add a helper to `app/agents/data/tools.py` (near `cohort_analysis`):
+
+```python
+async def _cohort_entity_id(months: int) -> "UUID":
+    """Build / fetch the kg_entities row representing this cohort window."""
+    from app.services.intelligence import get_or_create_entity
+    return await get_or_create_entity(
+        canonical_name=f"cohort_window_{months}m",
+        entity_type="metric",
+        domains=["data"],
+    )
+```
+
+Then at the top of `cohort_analysis`, before calling `CohortAnalysisService`:
+
+```python
+from app.services.intelligence import (
+    find_claims, should_query_graph, to_band,
+)
+from app.services.intelligence.presets import data_confidence
+
+entity_id = await _cohort_entity_id(months)
+decision = await should_query_graph(
+    entity_id=entity_id,
+    claim_type="cohort_summary",
+    agent_id="data",
+    freshness_threshold_hours=24.0,
+)
+if decision.verdict == "fresh":
+    # Pull the most recent matching claim and return it
+    claims = await find_claims(
+        entity_id=entity_id, claim_type="cohort_summary", agent_id="data", limit=1,
+    )
+    if claims:
+        c = claims[0]
+        return {
+            "from_cache": True,
+            "cache_tier": "graph",
+            "finding_text": c.finding_text,
+            "confidence": c.confidence,
+            "band": c.band,
+            "freshness_hours": decision.freshness_hours,
+            "sources": [s.model_dump(exclude_none=True) for s in c.sources],
+        }
+    # else fall through to computation
+```
+
+Add `"from_cache": False, "cache_tier": None` to the response payload before returning from the normal path, so downstream callers can always tell.
+
+- [ ] **Step 4: Re-run — should PASS**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py -k "graph" -v --tb=short
+```
+
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/agents/data/tools.py tests/integration/test_data_cache_integration.py
+git commit -m "feat(113-02): graph-tier short-circuit in cohort_analysis (GREEN)"
+```
+
+### Task 3: Wire Redis-tier caching around the Stripe call (TDD)
+
+**Files:**
+- Modify: `app/services/cohort_analysis_service.py` (where Stripe is called) OR `app/agents/data/tools.py` (if the cache wraps at the tool layer)
+- Modify: `tests/integration/test_data_cache_integration.py` (append)
+
+The implementer chooses the wrap layer based on Task 1 Step 2's audit. If `CohortAnalysisService.analyze` itself calls Stripe internally, wrap there. If `cohort_analysis` in tools.py orchestrates the Stripe call directly, wrap there.
+
+- [ ] **Step 1: Append Redis-tier tests** to `test_data_cache_integration.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Redis-tier: Stripe payload is cached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stripe_payload_cached_in_redis():
+    """A repeated cohort_analysis call within the Redis TTL doesn't re-call Stripe."""
+    from app.agents.data.tools import cohort_analysis
+
+    fake_stripe_response = {"transactions": [{"id": "ch_test_1"}]}
+    fake_service = AsyncMock()
+    fake_service.analyze = AsyncMock(return_value={
+        "retention_data": {"cohorts": [{"cohort_size": 100}]},
+        "ltv_breakdown": {}, "executive_summary": "x", "chart_data": {},
+    })
+
+    call_count = {"n": 0}
+
+    async def fake_stripe_call(*args, **kwargs):
+        call_count["n"] += 1
+        return fake_stripe_response
+
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ), patch(
+        # Replace with the actual Stripe-call path from Task 1's audit
+        "app.services.cohort_analysis_service._fetch_stripe_transactions",
+        side_effect=fake_stripe_call,
+    ):
+        # First call hits Stripe
+        await cohort_analysis(months=6)
+        first_count = call_count["n"]
+        # Second call within 300s should hit Redis, not Stripe
+        await cohort_analysis(months=6)
+        second_count = call_count["n"]
+
+    # The second call shouldn't increment Stripe call count
+    assert second_count == first_count, "Repeated cohort_analysis within TTL should hit Redis cache"
+```
+
+If the actual Stripe call path isn't `_fetch_stripe_transactions`, adjust the patch target to whatever Task 1 found.
+
+- [ ] **Step 2: Run — should FAIL**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py -k "stripe" -v --tb=short
+```
+
+- [ ] **Step 3: Wire the Redis cache around the Stripe call**
+
+In the function identified by Task 1 (Stripe call site), wrap as:
+
+```python
+from app.services.intelligence import should_call_external
+from app.services.cache import get_cache_service
+
+async def _fetch_stripe_transactions(months: int, user_id: str) -> dict:
+    """Fetch Stripe transactions for the cohort window.
+
+    Cached in Redis via the shared adaptive cache (Plan 113-02). 5-minute TTL
+    matches Stripe's append-only data model — recent transactions are stable.
+    """
+    cache_key = f"stripe:cohort_raw:{months}m:{user_id}"
+    decision = await should_call_external(cache_key=cache_key, ttl_seconds=300)
+    cache = get_cache_service()
+
+    if decision.verdict == "fresh":
+        value, _age = await cache.get_with_age(cache_key)
+        if value is not None:
+            return value
+
+    # Cache miss or stale — call Stripe
+    result = await _real_stripe_fetch(months=months, user_id=user_id)
+    await cache.set_with_age(cache_key, result, ttl=300)
+    return result
+```
+
+If the existing Stripe-fetch function has a different signature, adapt — the pattern is `decision → cache.get_with_age on fresh → fall through to real fetch → set_with_age`.
+
+- [ ] **Step 4: Re-run — should PASS**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py -k "stripe" -v --tb=short
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/cohort_analysis_service.py tests/integration/test_data_cache_integration.py
+git commit -m "feat(113-02): redis-tier caching around Stripe call (GREEN)"
+```
+
+### Task 4: Synthetic load test for cache effectiveness
+
+**Files:**
+- Create: `tests/integration/test_data_cache_load.py`
+
+The spec's acceptance criterion is "Stripe API call rate reduced by ≥40% during synthetic 1000-request burst." We don't actually need 1000 requests for the test — a smaller burst that demonstrates the same hit-rate property is sufficient and faster.
+
+- [ ] **Step 1: Create the load test**
+
+```python
+"""Synthetic load test: confirm Stripe call count is reduced by Plan 113-02 caching."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "REDIS_PASSWORD"]
+        ),
+        reason="env vars not provided",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_stripe_call_rate_below_60pct_of_request_count():
+    """Across 20 cohort_analysis calls, Stripe is hit fewer than 12 times (>=40% reduction)."""
+    from app.agents.data.tools import cohort_analysis
+
+    fake_service = AsyncMock()
+    fake_service.analyze = AsyncMock(return_value={
+        "retention_data": {"cohorts": [{"cohort_size": 100}]},
+        "ltv_breakdown": {}, "executive_summary": "x", "chart_data": {},
+    })
+
+    stripe_calls = 0
+
+    async def counting_stripe(*args, **kwargs):
+        nonlocal stripe_calls
+        stripe_calls += 1
+        return {"transactions": []}
+
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ), patch(
+        "app.services.cohort_analysis_service._fetch_stripe_transactions",
+        side_effect=counting_stripe,
+    ):
+        for _ in range(20):
+            await cohort_analysis(months=6)
+
+    # 1 cold call + at most 0 warm calls (TTL holds for the duration of the test)
+    # Acceptance: <=12 Stripe calls out of 20 requests (>= 40% reduction)
+    assert stripe_calls <= 12, (
+        f"Expected <=12 Stripe calls; got {stripe_calls}. "
+        "Cache wiring may not be hitting."
+    )
+```
+
+- [ ] **Step 2: Run**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_load.py -v
+```
+
+Expected: PASS, `stripe_calls == 1` (one cold call, 19 warm Redis hits within TTL).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_data_cache_load.py
+git commit -m "test(113-02): synthetic load test for cache effectiveness (>=40% Stripe reduction)"
+```
+
+### Task 5: Lint + acceptance sign-off
+
+- [ ] **Step 1: Lint**
+
+```powershell
+uv run ruff check app/agents/data/tools.py app/services/cohort_analysis_service.py tests/integration/test_data_cache_integration.py tests/integration/test_data_cache_load.py
+uv run ruff format app/agents/data/tools.py app/services/cohort_analysis_service.py tests/integration/test_data_cache_integration.py tests/integration/test_data_cache_load.py --check
+```
+
+Fix in-place; commit any fixes.
+
+- [ ] **Step 2: Final test run**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py tests/integration/test_data_cache_load.py tests/unit/services/intelligence/ -v --tb=short 2>&1 | Select-Object -Last 10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Acceptance check against spec**
+
+| Spec line | Where verified |
+|---|---|
+| Graph-tier short-circuit on fresh claims | Task 2 + `test_cohort_analysis_short_circuits_on_fresh_graph_claim` |
+| Redis-tier caching around Stripe calls | Task 3 + `test_stripe_payload_cached_in_redis` |
+| Stripe call rate reduced ≥40% on repeated load | Task 4 + `test_stripe_call_rate_below_60pct_of_request_count` |
+| No cache-poisoning regression (graph-stale path) | Implicit — `verdict="stale"` falls through to computation |
+| Two-tier substrate semantically distinct | Graph stores epistemic claims (cohort_summary); Redis stores raw Stripe payload — separate cache keys |
+| No new ADK tools | This plan is library-only |
+
+- [ ] **Step 4: Plan 113-02 complete. Plan 113-03 (claim emission rules) is unblocked.**
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task(s) |
+|---|---|
+| `should_query_graph` wraps `cohort_analysis` head | Task 2 |
+| `should_call_external` wraps Stripe call | Task 3 |
+| `CacheService.set_with_age` used for Redis writes | Task 3 |
+| ≥40% Stripe call reduction measurable | Task 4 |
+| Integration tests against real Supabase + Redis | All tasks |
+| No new ADK tools | Library only |
+
+All spec lines covered.

--- a/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-03-claim-emission.md
+++ b/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-03-claim-emission.md
@@ -1,0 +1,413 @@
+# Shared Intelligence Infrastructure — Plan 113-03: Data Agent Claim Emission
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Define the claim_type vocabulary and wire `write_claim` / `write_claims` into `cohort_analysis` so Data Agent's analytical outputs become `kg_findings` rows. After this plan ships, the graph-tier cache (Plan 113-02) starts actually hitting because there are claims to find.
+
+**Architecture:** Two emissions per `cohort_analysis` call: (a) one **summary claim** with the full executive summary text + average retention + overall confidence, used by `should_query_graph` for short-circuit, and (b) **per-month retention claims** (one per cohort × month pair) for fine-grained semantic search in Plan 113-04. Raw aggregations (transaction lists, MRR numbers) stay OUT of the graph — they live only in Redis per the spec's emission rules.
+
+**Tech Stack:** `write_claim`, `write_claims`, `ClaimPayload`, `ClaimSource` from Plan 112-03. No new dependencies.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-18-shared-intelligence-infra-design.md` § Phase 113 § Claim emission rules
+
+**Out of scope for this plan:** Other Data Agent functions besides `cohort_analysis` (`weekly_report`, `query_analytics` adopt in later phases), embedding generation (`embed=False` everywhere here — Plan 113-04 turns it on for semantic search), contradiction detection (Plan 113-05).
+
+---
+
+## File structure
+
+**Create:**
+- `docs/intelligence/claim-types.md` — the claim_type vocabulary reference (one-pager so Phase 113+ adopters use consistent names)
+
+**Modify:**
+- `app/agents/data/tools.py:cohort_analysis` — append claim emission after computation
+- `tests/integration/test_data_cache_integration.py` — assert the claims show up in kg_findings
+
+**Reference (read-only):**
+- `app/services/intelligence/claims.py` — `write_claim`, `write_claims`, `ClaimPayload`
+- Spec § Phase 113 § "What outputs become claims (the call Plan 113-03 has to make)" — the emission rule table
+
+---
+
+## Pre-flight context
+
+The emission rule (from the spec):
+
+| Output type | Becomes a Claim? | Storage |
+|---|---|---|
+| Raw aggregation (e.g., "last month MRR = $48,234") | ❌ No | Redis only |
+| Cohort retention curve | ✅ One claim per (cohort, month) | `kg_findings`, claim_type=`cohort_retention_mN` |
+| Weekly report executive summary | ✅ One claim per insight | `kg_findings`, claim_type=`weekly_insight` |
+| Anomaly detection ("churn up 12%") | ✅ Yes | `kg_findings`, claim_type=`kpi_anomaly` |
+| Trend assertion ("revenue trending up") | ✅ Yes | `kg_findings`, claim_type=`revenue_trend` |
+| One-off SQL query answer | ❌ No (transient) | Response payload only |
+| Cohort sample sizes / row counts | ❌ No | Embedded in claim's `sources` JSONB |
+
+Principle: **a claim has epistemic content** — an assertion about the world worth recalling. Raw numbers stay in Redis.
+
+For Plan 113-03, `cohort_analysis` emits:
+1. **`cohort_summary`** — one per call. Used by Plan 113-02's graph short-circuit.
+2. **`cohort_retention_mN`** — one per (cohort, month) pair in the retention curve. Enables Plan 113-04's semantic search ("show me Q1 2026 month-3 retention").
+
+Environment quirks: same as prior plans (env vars, PowerShell for uv).
+
+---
+
+## Tasks
+
+### Task 1: Pre-flight + write the claim-type vocabulary doc
+
+**Files:**
+- Create: `docs/intelligence/claim-types.md`
+
+- [ ] **Step 1: Confirm Plans 112-03 and 113-01/02 are integrated**
+
+```bash
+grep -E "^async def (write_claim|write_claims)" app/services/intelligence/claims.py
+grep -nB 2 "data_confidence" app/agents/data/tools.py
+grep -nB 2 "should_query_graph" app/agents/data/tools.py
+```
+
+Expected: all present.
+
+- [ ] **Step 2: Create `docs/intelligence/claim-types.md`**
+
+```markdown
+# Claim-type vocabulary
+
+The `claim_type` column on `kg_findings` is a free-text discriminator
+used by `find_claims`, `should_query_graph`, and (in 113-04)
+`search_claims_semantic`. Consistent vocabulary across agents lets
+the Executive query "any claim of type X" without per-agent guessing.
+
+## Data Agent (Plan 113-03)
+
+| `claim_type` | What it represents | When emitted |
+|---|---|---|
+| `cohort_summary` | Single high-level finding per `cohort_analysis` call. Powers Plan 113-02's graph-tier short-circuit. | One per `cohort_analysis(months)` call. |
+| `cohort_retention_m1` ... `cohort_retention_m6` | Per-month retention rate within a cohort. One claim per (cohort, month) pair. | Multiple per `cohort_analysis` call — one per (cohort, month_offset) in the retention curve. |
+
+Reserved for future Data Agent plans (not emitted yet):
+
+| `claim_type` | What it represents | When emitted |
+|---|---|---|
+| `weekly_insight` | A single insight from `generate_weekly_report`. | Future Data Agent plan. |
+| `kpi_anomaly` | An anomaly detected against a baseline. | Future Data Agent plan. |
+| `revenue_trend` | Direction assertion ("revenue trending up Q1"). | Future Data Agent plan. |
+
+## Research Agent
+
+| `claim_type` | What it represents |
+|---|---|
+| `research_finding` | A finding emitted by the Research Agent's multi-track synthesis. The legacy default for pre-Plan-112-01 rows. |
+
+## How to add a new claim_type
+
+1. Pick a snake_case name that describes the *epistemic content* (not the
+   workflow that produced it). Prefer "what's claimed" over "how it was
+   measured" — e.g., `cohort_retention_m3` not `stripe_query_result_3`.
+2. Add it to the table above with: what it represents, when emitted.
+3. If the claim's writer is a new agent, document the agent_id naming
+   too (lowercase, matches the agent_id column in kg_findings).
+4. Run `find_claims(claim_type="<new_name>")` after the first emission
+   to confirm it lands.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/intelligence/claim-types.md
+git commit -m "docs(113-03): claim-type vocabulary reference"
+```
+
+### Task 2: Wire claim emission into `cohort_analysis` (TDD)
+
+**Files:**
+- Modify: `app/agents/data/tools.py:cohort_analysis` — append claim writes after computation
+- Modify: `tests/integration/test_data_cache_integration.py` — assert claims persist
+
+- [ ] **Step 1: Append the failing claim-emission tests** to `tests/integration/test_data_cache_integration.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Plan 113-03: claim emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_writes_summary_claim():
+    """After a fresh cohort_analysis, a cohort_summary claim exists in kg_findings."""
+    from app.agents.data.tools import _cohort_entity_id, cohort_analysis
+    from app.services.intelligence import find_claims
+
+    fake_service = AsyncMock()
+    fake_service.analyze = AsyncMock(return_value={
+        "retention_data": {
+            "cohorts": [
+                {"cohort_month": "2026-01", "cohort_size": 200,
+                 "retention_by_month": {1: 0.85, 2: 0.72, 3: 0.65}},
+            ],
+        },
+        "ltv_breakdown": {}, "executive_summary": "Stable retention in early cohorts.",
+        "chart_data": {},
+    })
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ):
+        await cohort_analysis(months=6)
+
+    entity_id = await _cohort_entity_id(6)
+    summaries = await find_claims(
+        entity_id=entity_id, claim_type="cohort_summary", agent_id="data", limit=5,
+    )
+    assert len(summaries) >= 1
+    assert summaries[0].finding_text  # non-empty
+    assert summaries[0].agent_id == "data"
+    assert summaries[0].domain == "data"
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_writes_per_month_retention_claims():
+    """After cohort_analysis, per-month retention claims exist (one per cohort × month)."""
+    from app.agents.data.tools import _cohort_entity_id, cohort_analysis
+    from app.services.intelligence import find_claims
+
+    fake_service = AsyncMock()
+    fake_service.analyze = AsyncMock(return_value={
+        "retention_data": {
+            "cohorts": [
+                {"cohort_month": "2026-01", "cohort_size": 200,
+                 "retention_by_month": {1: 0.85, 2: 0.72, 3: 0.65}},
+                {"cohort_month": "2026-02", "cohort_size": 180,
+                 "retention_by_month": {1: 0.88, 2: 0.74}},
+            ],
+        },
+        "ltv_breakdown": {}, "executive_summary": "ok", "chart_data": {},
+    })
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ):
+        await cohort_analysis(months=6)
+
+    entity_id = await _cohort_entity_id(6)
+    # We seeded 3 + 2 = 5 (cohort, month) points
+    m1 = await find_claims(
+        entity_id=entity_id, claim_type="cohort_retention_m1", agent_id="data", limit=10,
+    )
+    m2 = await find_claims(
+        entity_id=entity_id, claim_type="cohort_retention_m2", agent_id="data", limit=10,
+    )
+    m3 = await find_claims(
+        entity_id=entity_id, claim_type="cohort_retention_m3", agent_id="data", limit=10,
+    )
+    # At least one of each — fixture-row uniqueness across runs may vary so use >=
+    assert len(m1) >= 1, "cohort_retention_m1 claims should exist"
+    assert len(m2) >= 1, "cohort_retention_m2 claims should exist"
+    assert len(m3) >= 1, "cohort_retention_m3 claims should exist"
+```
+
+- [ ] **Step 2: Run — should FAIL** (`find_claims` returns empty; nothing's being written)
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py -k "writes_summary or per_month_retention" -v --tb=short
+```
+
+- [ ] **Step 3: Add claim emission to `cohort_analysis`**
+
+In `app/agents/data/tools.py:cohort_analysis`, after the computation block (after `data_confidence` has run, before the response is returned), add:
+
+```python
+from app.services.intelligence import write_claim, write_claims
+from app.services.intelligence.schemas import ClaimPayload, ClaimSource
+
+# Summary claim — powers the graph-tier short-circuit on next call
+exec_summary = str(result.get("executive_summary", "")).strip()
+if exec_summary:
+    try:
+        await write_claim(
+            entity_id=entity_id,
+            domain="data",
+            finding_text=exec_summary,
+            confidence=confidence,
+            sources=[{"kind": "stripe_row", "ref": f"cohort_window_{months}m"}],
+            agent_id="data",
+            claim_type="cohort_summary",
+        )
+    except Exception as e:
+        logger.warning("cohort_summary claim write failed: %s", e)
+
+# Per-month retention claims — fine-grained, enables 113-04 semantic search
+retention_data = result.get("retention_data", {})
+cohorts = retention_data.get("cohorts", []) if isinstance(retention_data, dict) else []
+payloads: list[ClaimPayload] = []
+for cohort in cohorts:
+    cohort_month = str(cohort.get("cohort_month", ""))
+    retention_by_month = cohort.get("retention_by_month", {})
+    if not isinstance(retention_by_month, dict):
+        continue
+    for month_offset, retention_rate in retention_by_month.items():
+        try:
+            mn = int(month_offset)
+        except (TypeError, ValueError):
+            continue
+        if mn < 1 or mn > 12:
+            continue
+        try:
+            rate = float(retention_rate)
+        except (TypeError, ValueError):
+            continue
+        payloads.append(ClaimPayload(
+            entity_id=entity_id,
+            domain="data",
+            finding_text=(
+                f"Cohort {cohort_month} month-{mn} retention = "
+                f"{rate * 100:.1f}%"
+            ),
+            confidence=confidence,
+            sources=[ClaimSource(
+                kind="stripe_row",
+                ref=f"cohort:{cohort_month}",
+            )],
+            agent_id="data",
+            claim_type=f"cohort_retention_m{mn}",
+        ))
+
+if payloads:
+    try:
+        await write_claims(payloads)
+    except Exception as e:
+        logger.warning("cohort_retention bulk write failed: %s", e)
+```
+
+Note: writes are wrapped in `try/except` because claim emission is a side-effect — a graph-write failure should NOT prevent the user from getting their cohort analysis result. This is a deliberate exception to the spec's "writes fail loudly" rule, specifically for *secondary persistence* in a tool that has primary work to deliver. Document via the inline comment.
+
+Also: make sure `logger` is imported at the top of `tools.py` (`import logging; logger = logging.getLogger(__name__)`).
+
+- [ ] **Step 4: Re-run — should PASS**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py -k "writes_summary or per_month_retention" -v --tb=short
+```
+
+- [ ] **Step 5: Confirm prior tests still pass**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py tests/integration/test_data_cache_load.py -v --tb=short 2>&1 | Select-Object -Last 10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/agents/data/tools.py tests/integration/test_data_cache_integration.py
+git commit -m "feat(113-03): emit cohort_summary + cohort_retention_mN claims (GREEN)"
+```
+
+### Task 3: Verify the graph-tier cache now actually hits
+
+**Files:** none modified — verification only.
+
+In Plan 113-02, the graph-tier short-circuit was wired but mostly missed because nothing was writing claims. Now Plan 113-03 writes them. Confirm the loop closes.
+
+- [ ] **Step 1: End-to-end cache loop test**
+
+Append to `tests/integration/test_data_cache_integration.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_second_cohort_call_hits_graph_cache():
+    """First cohort_analysis call writes claims; second call reads them and short-circuits."""
+    from app.agents.data.tools import cohort_analysis
+
+    fake_service = AsyncMock()
+    fake_service.analyze = AsyncMock(return_value={
+        "retention_data": {
+            "cohorts": [{"cohort_month": "2026-03", "cohort_size": 100,
+                         "retention_by_month": {1: 0.9}}],
+        },
+        "ltv_breakdown": {}, "executive_summary": "fresh test", "chart_data": {},
+    })
+
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ):
+        # Cold call — service hit, claims written
+        first = await cohort_analysis(months=6)
+        assert first.get("from_cache", False) is False
+        assert fake_service.analyze.call_count == 1
+
+        # Warm call — graph cache hits, service NOT called again
+        second = await cohort_analysis(months=6)
+        assert second.get("from_cache") is True
+        assert second.get("cache_tier") == "graph"
+        # The mock service call count should still be 1
+        assert fake_service.analyze.call_count == 1
+```
+
+- [ ] **Step 2: Run**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py::test_second_cohort_call_hits_graph_cache -v --tb=short
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_data_cache_integration.py
+git commit -m "test(113-03): verify graph cache hit on second cohort_analysis call"
+```
+
+### Task 4: Lint + acceptance sign-off
+
+- [ ] **Step 1: Lint**
+
+```powershell
+uv run ruff check app/agents/data/tools.py docs/intelligence/ tests/integration/test_data_cache_integration.py
+uv run ruff format app/agents/data/tools.py tests/integration/test_data_cache_integration.py --check
+```
+
+Fix in-place; commit any fixes.
+
+- [ ] **Step 2: Final cross-cutting test run**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py tests/integration/test_data_cache_load.py tests/unit/services/intelligence/ -v --tb=short 2>&1 | Select-Object -Last 15
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Acceptance check against spec**
+
+| Spec line | Where verified |
+|---|---|
+| Raw aggregations stay OUT of `kg_findings` | Implementation: no MRR / transaction-list writes |
+| Cohort retention curves persist as per-month claims | Task 2 + `test_cohort_analysis_writes_per_month_retention_claims` |
+| Weekly summary insights would persist (vocabulary reserved) | `docs/intelligence/claim-types.md` reserves `weekly_insight` for a future plan |
+| Claim-type vocabulary documented | Task 1 |
+| Graph cache hit rate >=60% for repeated cohort_analysis | Task 3 — single hit-rate of 100% on the test, well above 60% |
+| Writes wrapped in try/except (claim emission is secondary) | Task 2 + inline comment |
+| No new ADK tools | This plan is library-only |
+
+- [ ] **Step 4: Plan 113-03 complete. Plan 113-04 (`search_claims_semantic` + pgvector) is unblocked.**
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task(s) |
+|---|---|
+| Claim-type vocabulary established | Task 1 |
+| `cohort_analysis` writes `cohort_summary` claim | Task 2 |
+| `cohort_analysis` writes per-month `cohort_retention_mN` claims | Task 2 |
+| Bulk insert via `write_claims` | Task 2 |
+| Graph short-circuit now hits on repeat | Task 3 |
+| Secondary-write exception to "writes fail loudly" documented | Task 2 inline comment |
+| Lint clean | Task 4 |
+
+All spec lines covered.

--- a/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-04-semantic-search.md
+++ b/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-04-semantic-search.md
@@ -1,0 +1,714 @@
+# Shared Intelligence Infrastructure — Plan 113-04: Semantic Search + Executive ADK Tool
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `search_claims_semantic(query, agent_id?, claim_type?, top_k)` to the intelligence package — pgvector-backed semantic search across all agents' claims. Turn on `embed=True` for cohort summary claims so they become searchable. Expose the search as the **first justified ADK tool wrapper** in the package (per the spec, reasoning-driven retrieval is where LLM tool calls add value).
+
+**Architecture:** New migration adds an `ivfflat` index on `kg_findings.embedding` (conservative for ≤500k rows; migrate to `hnsw` later if needed). `search_claims_semantic` generates an embedding for the query, runs `ORDER BY embedding <=> $1` via pgvector, and returns `list[tuple[Claim, float similarity]]`. Executive Agent gains an ADK tool `search_agent_claims` that wraps the function with sensible defaults (top_k=10).
+
+**Tech Stack:** pgvector (already installed for `kg_entities.embedding` + `kg_findings.embedding`), `app/rag/embedding_service.generate_embedding` (sync, wrapped to async per Plan 112-03's `_embed_text`), the ADK tool registration pattern from `app/agents/specialized_agents.py`.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-18-shared-intelligence-infra-design.md` § Phase 113 § Cross-agent semantic search
+
+**Out of scope:** Contradiction detection (Plan 113-05), tuning ivfflat lists or migration to hnsw, full-text search fallback for when embedding generation fails.
+
+---
+
+## File structure
+
+**Create:**
+- `supabase/migrations/20260519000000_kg_findings_embedding_ivfflat_index.sql` — pgvector index
+- `app/agents/tools/intelligence_search.py` — ADK tool wrapper for Executive
+- `tests/unit/services/intelligence/test_search.py` — unit tests with mocked embedding + DB
+- `tests/integration/test_intelligence_search.py` — integration tests against real pgvector
+
+**Modify:**
+- `app/services/intelligence/claims.py` — add `search_claims_semantic` async function
+- `app/services/intelligence/__init__.py` — re-export `search_claims_semantic`
+- `app/agents/data/tools.py` — flip `embed=True` on the `cohort_summary` write
+- `app/agent.py` (ExecutiveAgent) — register the new `search_agent_claims` ADK tool
+
+**Reference (read-only):**
+- `app/agents/research/tools/synthesizer.py` — pattern for embedding-on-write
+- `app/rag/embedding_service.py` — `generate_embedding` (sync)
+- `supabase/migrations/20260321500000_knowledge_graph.sql` — see how `kg_entities.embedding` index is defined (line 47 — `USING hnsw (embedding vector_cosine_ops)`)
+
+---
+
+## Pre-flight context
+
+Note: `kg_entities` already has an HNSW index on its embedding column. For `kg_findings.embedding`, the spec recommends starting with `ivfflat` (`lists=100`) for ≤500k rows, migrating to `hnsw` only if needed. Why the divergence:
+- Entities are sparse (~1 row per topic); HNSW gives fast lookup with low memory overhead
+- Findings will be dense (potentially many per topic); ivfflat scales better to large row counts on commodity hardware
+
+You can override this choice if you have reason — just document it in the migration's comment.
+
+`search_claims_semantic` signature per spec:
+```python
+async def search_claims_semantic(
+    *, query: str,
+    agent_id: str | None = None,
+    claim_type: str | None = None,
+    top_k: int = 10,
+) -> list[tuple[Claim, float]]:  # (claim, similarity)
+```
+
+Performance target (from spec): p50 ≤ 200ms with 100k claims in table. ivfflat at `lists=100` typically delivers this; ANALYZE the table after migration to make sure the planner picks the index.
+
+Acceptance bar:
+- Returns Research findings AND Data claims for a query about a shared topic
+- pgvector index used (verified via `EXPLAIN ANALYZE`)
+- Executive ADK tool registered and discoverable
+
+Environment quirks: same as prior plans.
+
+---
+
+## Tasks
+
+### Task 1: pgvector index migration
+
+**Files:**
+- Create: `supabase/migrations/20260519000000_kg_findings_embedding_ivfflat_index.sql`
+
+- [ ] **Step 1: Create the migration**
+
+```sql
+-- =============================================================================
+-- Plan 113-04: ivfflat index on kg_findings.embedding for semantic search.
+--
+-- Why ivfflat (not hnsw): kg_findings is expected to grow into the hundreds
+-- of thousands of rows. ivfflat with lists=100 is conservative for that scale
+-- and uses materially less memory than hnsw. Migrate to hnsw if and when:
+--   - row count exceeds 1M
+--   - p50 query latency exceeds 200ms despite tuning
+--
+-- ROLLBACK:
+--   DROP INDEX IF EXISTS idx_kg_findings_embedding_semantic;
+--
+-- PRODUCTION DEPLOY NOTE: for large tables, build via CREATE INDEX
+-- CONCURRENTLY outside a transaction (mirrors the kg_findings broaden
+-- migration runbook). The form below uses regular CREATE INDEX inside
+-- BEGIN/COMMIT for local dev; prod deploy script must switch to
+-- CONCURRENTLY.
+-- =============================================================================
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_kg_findings_embedding_semantic
+    ON kg_findings USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 100);
+
+-- Tell the planner about the new index
+ANALYZE kg_findings;
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply locally**
+
+```powershell
+Get-Content supabase/migrations/20260519000000_kg_findings_embedding_ivfflat_index.sql | docker exec -i supabase_db_Pikar-Ai psql -U postgres -d postgres
+```
+
+Expected: BEGIN / CREATE INDEX / ANALYZE / COMMIT.
+
+- [ ] **Step 3: Verify the index exists**
+
+```powershell
+docker exec supabase_db_Pikar-Ai psql -U postgres -d postgres -c "\d kg_findings" | Select-String "idx_kg_findings_embedding_semantic"
+```
+
+Expected: prints the index line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260519000000_kg_findings_embedding_ivfflat_index.sql
+git commit -m "feat(113-04): add ivfflat index on kg_findings.embedding for semantic search"
+```
+
+### Task 2: Implement `search_claims_semantic` (TDD)
+
+**Files:**
+- Create: `tests/unit/services/intelligence/test_search.py`
+- Modify: `app/services/intelligence/claims.py` — append the new function
+- Modify: `app/services/intelligence/__init__.py` — re-export
+
+- [ ] **Step 1: Failing unit test**
+
+```python
+"""Unit tests for search_claims_semantic with mocked embedding + DB."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_search_claims_semantic_returns_claims_ordered_by_similarity():
+    """Mocked DB returns 3 rows; result preserves order and packs Claim objects."""
+    from app.services.intelligence.claims import search_claims_semantic
+
+    fake_rows = [
+        {
+            "id": str(uuid4()),
+            "entity_id": str(uuid4()), "edge_id": None,
+            "agent_id": "data", "claim_type": "cohort_summary",
+            "domain": "data", "finding_text": "very similar",
+            "confidence": 0.9, "sources": [], "contradicts": [],
+            "freshness_at": "2026-05-19T12:00:00+00:00",
+            "expires_at": None, "created_at": "2026-05-19T11:55:00+00:00",
+            "similarity": 0.05,  # closer = lower distance
+        },
+        {
+            "id": str(uuid4()),
+            "entity_id": str(uuid4()), "edge_id": None,
+            "agent_id": "research", "claim_type": "research_finding",
+            "domain": "research", "finding_text": "somewhat similar",
+            "confidence": 0.7, "sources": [], "contradicts": [],
+            "freshness_at": "2026-05-19T10:00:00+00:00",
+            "expires_at": None, "created_at": "2026-05-19T09:55:00+00:00",
+            "similarity": 0.4,
+        },
+    ]
+    fake_embed = [0.1] * 768
+
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=fake_embed),
+    ), patch(
+        "app.services.intelligence.claims._semantic_query_rows",
+        new=AsyncMock(return_value=fake_rows),
+    ):
+        results = await search_claims_semantic(query="cohort retention", top_k=5)
+
+    assert len(results) == 2
+    # Each result is (Claim, similarity float)
+    first_claim, first_sim = results[0]
+    assert first_claim.finding_text == "very similar"
+    assert first_sim == pytest.approx(0.05)
+    second_claim, second_sim = results[1]
+    assert second_claim.finding_text == "somewhat similar"
+    assert second_sim == pytest.approx(0.4)
+
+
+@pytest.mark.asyncio
+async def test_search_claims_semantic_skips_when_embedding_fails():
+    """If embedding generation fails, return [] (degrade silently — read path)."""
+    from app.services.intelligence.claims import search_claims_semantic
+
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=None),
+    ):
+        results = await search_claims_semantic(query="anything")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_search_claims_semantic_top_k_respected():
+    """The top_k argument caps the number of rows fetched."""
+    from app.services.intelligence.claims import search_claims_semantic
+
+    fake_embed = [0.1] * 768
+    captured = {}
+
+    async def capture_query(*, embedding, agent_id, claim_type, top_k):
+        captured["top_k"] = top_k
+        return []
+
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=fake_embed),
+    ), patch(
+        "app.services.intelligence.claims._semantic_query_rows",
+        side_effect=capture_query,
+    ):
+        await search_claims_semantic(query="x", top_k=3)
+
+    assert captured["top_k"] == 3
+```
+
+- [ ] **Step 2: Run — should FAIL**
+
+```powershell
+uv run pytest tests/unit/services/intelligence/test_search.py -v --tb=short
+```
+
+- [ ] **Step 3: Implement in `claims.py`**
+
+Add to `app/services/intelligence/claims.py` (append after the existing functions):
+
+```python
+async def search_claims_semantic(
+    *,
+    query: str,
+    agent_id: str | None = None,
+    claim_type: str | None = None,
+    top_k: int = 10,
+) -> list[tuple[Claim, float]]:
+    """Semantic search across kg_findings.embedding.
+
+    Embeds the query, runs pgvector cosine-distance ORDER BY, and returns
+    (Claim, similarity) tuples — lower similarity = closer match.
+
+    Reads degrade silently: embedding-generation failure or DB failure
+    returns []. Caller may show "no semantic results" or fall back to
+    structured search.
+
+    Args:
+        query: Natural-language search string.
+        agent_id: Restrict to a specific agent (e.g., "data", "research").
+        claim_type: Restrict to a specific claim_type.
+        top_k: Max rows returned. Capped at 100 internally to avoid runaway.
+
+    Returns:
+        list[tuple[Claim, float]] sorted by similarity ASCENDING (closest first).
+        Empty list on failure or no matches.
+    """
+    embedding = await _embed_text(query)
+    if embedding is None:
+        return []
+
+    top_k = max(1, min(top_k, 100))  # safety cap
+
+    try:
+        rows = await _semantic_query_rows(
+            embedding=embedding,
+            agent_id=agent_id,
+            claim_type=claim_type,
+            top_k=top_k,
+        )
+    except Exception as e:
+        logger.warning("search_claims_semantic query failed: %s", e)
+        return []
+
+    from app.services.intelligence.schemas import ClaimSource
+    results: list[tuple[Claim, float]] = []
+    for r in rows:
+        sources_raw = r.get("sources") or []
+        sources = [
+            ClaimSource(**s) if isinstance(s, dict) else ClaimSource(kind="other", ref=str(s))
+            for s in sources_raw
+        ]
+        claim = Claim(
+            id=UUID(r["id"]),
+            entity_id=UUID(r["entity_id"]) if r.get("entity_id") else None,
+            edge_id=UUID(r["edge_id"]) if r.get("edge_id") else None,
+            agent_id=r["agent_id"],
+            claim_type=r["claim_type"],
+            domain=r["domain"],
+            finding_text=r["finding_text"],
+            confidence=float(r["confidence"]),
+            sources=sources,
+            contradicts=[UUID(c) for c in (r.get("contradicts") or [])],
+            freshness_at=datetime.fromisoformat(r["freshness_at"].replace("Z", "+00:00"))
+                if isinstance(r["freshness_at"], str) else r["freshness_at"],
+            expires_at=datetime.fromisoformat(r["expires_at"].replace("Z", "+00:00"))
+                if r.get("expires_at") and isinstance(r["expires_at"], str) else r.get("expires_at"),
+            created_at=datetime.fromisoformat(r["created_at"].replace("Z", "+00:00"))
+                if isinstance(r["created_at"], str) else r["created_at"],
+        )
+        similarity = float(r.get("similarity", 0.0))
+        results.append((claim, similarity))
+    return results
+
+
+async def _semantic_query_rows(
+    *,
+    embedding: list[float],
+    agent_id: str | None,
+    claim_type: str | None,
+    top_k: int,
+) -> list[dict]:
+    """Execute the pgvector ORDER BY query and return raw rows.
+
+    Isolated as a helper so tests can mock the DB hop without mocking
+    the whole search_claims_semantic.
+    """
+    # Build the SQL — pgvector uses <=> for cosine distance
+    where_clauses = []
+    params: list = [embedding, top_k]
+    if agent_id is not None:
+        params.append(agent_id)
+        where_clauses.append(f"agent_id = ${len(params)}")
+    if claim_type is not None:
+        params.append(claim_type)
+        where_clauses.append(f"claim_type = ${len(params)}")
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+
+    sql = f"""
+        SELECT id, entity_id, edge_id, agent_id, claim_type, domain,
+               finding_text, confidence, sources, contradicts,
+               freshness_at, expires_at, created_at,
+               (embedding <=> $1) AS similarity
+          FROM kg_findings
+          {where_sql}
+         ORDER BY embedding <=> $1
+         LIMIT $2
+    """
+
+    # Run via psycopg directly — the supabase python client doesn't
+    # expose vector parameters cleanly enough for this pattern.
+    import os
+    import psycopg
+    dsn = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.warning("SUPABASE_DB_URL not set; semantic search unavailable")
+        return []
+
+    def _run():
+        with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            cols = [d[0] for d in cur.description]
+            return [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
+
+    import asyncio
+    return await asyncio.get_event_loop().run_in_executor(None, _run)
+```
+
+- [ ] **Step 4: Update `__init__.py`** to re-export `search_claims_semantic`:
+
+```python
+# Add to the imports block:
+from app.services.intelligence.claims import (
+    claim_freshness_hours,
+    find_claims,
+    get_or_create_entity,
+    search_claims_semantic,  # NEW
+    write_claim,
+    write_claims,
+)
+
+# Add "search_claims_semantic" to __all__
+```
+
+- [ ] **Step 5: Re-run unit tests — should PASS**
+
+```powershell
+uv run pytest tests/unit/services/intelligence/test_search.py -v --tb=short
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/intelligence/claims.py app/services/intelligence/__init__.py tests/unit/services/intelligence/test_search.py
+git commit -m "feat(113-04): implement search_claims_semantic with pgvector cosine distance (GREEN)"
+```
+
+### Task 3: Turn on `embed=True` for cohort_summary writes
+
+**Files:**
+- Modify: `app/agents/data/tools.py:cohort_analysis` — flip `embed=True` on the `cohort_summary` `write_claim`
+
+- [ ] **Step 1: Edit**
+
+In the `cohort_summary` `write_claim` call (added in Plan 113-03), change `embed=False` (or omitted, defaults to False) to `embed=True`. Per-month `cohort_retention_mN` claims stay at `embed=False` — those are short numerical claims with low semantic search value.
+
+Also: confirm `app/rag/embedding_service.generate_embedding` exists and is callable. If it returns sync, `_embed_text` already handles that wrapper (Plan 112-03's helper).
+
+- [ ] **Step 2: Run prior test to confirm no regression**
+
+```powershell
+uv run pytest tests/integration/test_data_cache_integration.py -k "writes_summary" -v --tb=short
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/agents/data/tools.py
+git commit -m "feat(113-04): enable embeddings on cohort_summary claims for semantic search"
+```
+
+### Task 4: Integration test — semantic search round-trip
+
+**Files:**
+- Create: `tests/integration/test_intelligence_search.py`
+
+- [ ] **Step 1: Create the test**
+
+```python
+"""Integration test: write claims with embeddings, then semantic-search them."""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var) for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="env not set",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_returns_relevant_claims():
+    """Write two distinct claims (one about cohorts, one about regulations);
+    search for 'cohort retention' should rank the cohort claim higher.
+    """
+    from app.services.intelligence import (
+        get_or_create_entity, search_claims_semantic, write_claim,
+    )
+
+    e1 = await get_or_create_entity(
+        canonical_name=f"semantic_cohort_{uuid4()}",
+        entity_type="metric", domains=["data"],
+    )
+    e2 = await get_or_create_entity(
+        canonical_name=f"semantic_compliance_{uuid4()}",
+        entity_type="regulation", domains=["compliance"],
+    )
+
+    await write_claim(
+        entity_id=e1, domain="data",
+        finding_text="Customer cohort retention dropped 12% in Q1 driven by enterprise churn",
+        confidence=0.85,
+        sources=[{"kind": "stripe_row", "ref": "test"}],
+        agent_id="data", claim_type="cohort_summary",
+        embed=True,
+    )
+    await write_claim(
+        entity_id=e2, domain="compliance",
+        finding_text="GDPR Article 17 mandates erasure of personal data on request",
+        confidence=0.95,
+        sources=[{"kind": "regulation", "ref": "GDPR Art 17"}],
+        agent_id="compliance", claim_type="regulation_summary",
+        embed=True,
+    )
+
+    results = await search_claims_semantic(
+        query="cohort retention drop", top_k=5,
+    )
+
+    assert len(results) >= 1
+    # The first result should be the cohort claim (semantic neighbour),
+    # NOT the GDPR claim. We accept any plausible ordering as long as
+    # the cohort claim ranks above the GDPR claim if both are returned.
+    cohort_position = None
+    gdpr_position = None
+    for i, (claim, _sim) in enumerate(results):
+        if "cohort" in claim.finding_text.lower():
+            cohort_position = i if cohort_position is None else cohort_position
+        if "GDPR" in claim.finding_text:
+            gdpr_position = i if gdpr_position is None else gdpr_position
+    assert cohort_position is not None, "Cohort claim should appear in top results"
+    if gdpr_position is not None:
+        assert cohort_position < gdpr_position, "Cohort claim should rank above GDPR claim"
+```
+
+- [ ] **Step 2: Run**
+
+```powershell
+uv run pytest tests/integration/test_intelligence_search.py -v --tb=short
+```
+
+Expected: PASS. If the ordering fails, the embedding service may be returning a low-quality vector — investigate before changing the assertion.
+
+- [ ] **Step 3: Verify pgvector index is used** via `EXPLAIN ANALYZE` (sanity check, not a test assertion):
+
+```powershell
+docker exec supabase_db_Pikar-Ai psql -U postgres -d postgres -c "EXPLAIN ANALYZE SELECT id FROM kg_findings WHERE embedding IS NOT NULL ORDER BY embedding <=> ARRAY[0.1, 0.2, 0.3]::vector LIMIT 5;"
+```
+
+Look for `Index Scan using idx_kg_findings_embedding_semantic` in the plan. If you see a Seq Scan, the planner thinks the table is too small to bother — that's fine for local dev; prod will use the index.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_intelligence_search.py
+git commit -m "test(113-04): integration test for semantic search across agents"
+```
+
+### Task 5: Add Executive ADK tool wrapper
+
+**Files:**
+- Create: `app/agents/tools/intelligence_search.py`
+- Modify: `app/agent.py` — register the new tool
+
+This is the **first justified ADK tool wrapper** in the intelligence package. The Executive LLM gets to decide when semantic search is worth invoking, with what filters.
+
+- [ ] **Step 1: Create `app/agents/tools/intelligence_search.py`**
+
+```python
+"""ADK tool: cross-agent semantic claim search.
+
+Wraps app.services.intelligence.search_claims_semantic with sensible defaults
+for the Executive Agent. The LLM decides when this is worth calling
+(reasoning-driven retrieval, not a mechanical lookup).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def search_agent_claims(
+    query: str,
+    agent_id: str | None = None,
+    claim_type: str | None = None,
+    top_k: int = 10,
+) -> dict[str, Any]:
+    """Search all agents' knowledge-graph claims by semantic similarity.
+
+    Returns claims any specialized agent has written about a topic — useful
+    when the Executive needs to recall what's known across the team.
+
+    Args:
+        query: Natural-language search string (e.g., "Q1 customer retention").
+        agent_id: Optional — restrict to a specific agent. Examples:
+                  "data", "research", "financial", "compliance".
+        claim_type: Optional — restrict to a single claim_type. See
+                    docs/intelligence/claim-types.md for the vocabulary.
+        top_k: Max results to return. Default 10; capped at 100.
+
+    Returns:
+        Dict with `results: list[{finding_text, confidence, band, agent_id,
+        claim_type, similarity, domain, sources}]` and `count: int`.
+    """
+    from app.services.intelligence import search_claims_semantic
+
+    try:
+        hits = await search_claims_semantic(
+            query=query,
+            agent_id=agent_id,
+            claim_type=claim_type,
+            top_k=top_k,
+        )
+    except Exception as e:
+        logger.warning("search_agent_claims failed: %s", e)
+        return {"results": [], "count": 0, "error": str(e)}
+
+    results: list[dict[str, Any]] = []
+    for claim, similarity in hits:
+        results.append({
+            "finding_text": claim.finding_text,
+            "confidence": claim.confidence,
+            "band": claim.band,
+            "agent_id": claim.agent_id,
+            "claim_type": claim.claim_type,
+            "domain": claim.domain,
+            "similarity": similarity,
+            "sources": [s.model_dump(exclude_none=True) for s in claim.sources],
+            "freshness_at": claim.freshness_at.isoformat(),
+        })
+
+    return {"results": results, "count": len(results)}
+
+
+# ADK tool export
+INTELLIGENCE_SEARCH_TOOLS = [search_agent_claims]
+```
+
+- [ ] **Step 2: Wire into `app/agent.py`** (ExecutiveAgent)
+
+Find the ExecutiveAgent's tool list assembly in `app/agent.py`. Add the import and extend the tool list:
+
+```python
+from app.agents.tools.intelligence_search import INTELLIGENCE_SEARCH_TOOLS
+
+# In the tool-list build site, e.g.:
+tools = [
+    *KNOWLEDGE_SEARCH_TOOLS,
+    *BRAIN_DUMP_TOOLS,
+    # ...
+    *INTELLIGENCE_SEARCH_TOOLS,
+]
+```
+
+The exact insertion point depends on the current structure — find where tool lists are accumulated and add the new one.
+
+- [ ] **Step 3: Verify the tool is discoverable**
+
+```powershell
+uv run python -c "
+from app.agents.tools.intelligence_search import search_agent_claims, INTELLIGENCE_SEARCH_TOOLS
+print('tool import OK; tool count =', len(INTELLIGENCE_SEARCH_TOOLS))
+"
+```
+
+Expected: `tool import OK; tool count = 1`.
+
+- [ ] **Step 4: Smoke-test through the ADK tool layer**
+
+```powershell
+$env:SUPABASE_URL = "http://127.0.0.1:54321"
+$env:SUPABASE_SERVICE_ROLE_KEY = (supabase status -o env | Select-String '^SERVICE_ROLE_KEY=').ToString().Split('=',2)[1].Trim('"')
+$env:SUPABASE_DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+uv run python -c "
+import asyncio
+from app.agents.tools.intelligence_search import search_agent_claims
+
+async def main():
+    result = await search_agent_claims(query='cohort retention', top_k=3)
+    print(f'count={result[\"count\"]}; first result agent={result[\"results\"][0][\"agent_id\"] if result[\"results\"] else \"<none>\"}')
+
+asyncio.run(main())
+"
+```
+
+Expected: prints a count + sample result (if any prior tests wrote claims with embeddings). If `count=0` on a fresh DB, that's expected — just confirm no exception.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/agents/tools/intelligence_search.py app/agent.py
+git commit -m "feat(113-04): add search_agent_claims ADK tool for Executive"
+```
+
+### Task 6: Lint + acceptance sign-off
+
+- [ ] **Step 1: Lint**
+
+```powershell
+uv run ruff check app/services/intelligence/claims.py app/agents/tools/intelligence_search.py tests/unit/services/intelligence/test_search.py tests/integration/test_intelligence_search.py
+uv run ruff format app/services/intelligence/claims.py app/agents/tools/intelligence_search.py tests/unit/services/intelligence/test_search.py tests/integration/test_intelligence_search.py --check
+```
+
+Fix in-place; commit any fixes.
+
+- [ ] **Step 2: Acceptance check**
+
+| Spec line | Verified by |
+|---|---|
+| `search_claims_semantic` async, returns `list[tuple[Claim, float]]` | Task 2 implementation |
+| pgvector index created | Task 1 migration |
+| Reads degrade silently on embedding failure | Task 2 + `test_search_claims_semantic_skips_when_embedding_fails` |
+| Executive ADK tool `search_agent_claims` registered | Task 5 |
+| Returns claims from multiple agents for a shared topic | Task 4 integration test |
+| `top_k` capped at 100 | Task 2 + `test_search_claims_semantic_top_k_respected` |
+| Embeddings now generated for cohort_summary writes | Task 3 |
+| No lint regressions | Task 6 |
+
+- [ ] **Step 3: Plan 113-04 complete. Plan 113-05 (`detect_contradictions`) is unblocked.**
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task(s) |
+|---|---|
+| ivfflat pgvector index on kg_findings.embedding | Task 1 |
+| `search_claims_semantic(query, agent_id?, claim_type?, top_k)` | Task 2 |
+| Reads degrade silently | Task 2 tests |
+| Executive ADK tool wrapper (first justified one) | Task 5 |
+| Embeddings on cohort_summary writes | Task 3 |
+| Integration test confirms cross-agent retrieval | Task 4 |
+| pgvector index actually used (EXPLAIN check) | Task 4 Step 3 |
+| Lint clean | Task 6 |
+
+All spec lines covered.

--- a/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-05-contradiction-detection.md
+++ b/docs/superpowers/plans/2026-05-19-shared-intelligence-infra-113-05-contradiction-detection.md
@@ -1,0 +1,729 @@
+# Shared Intelligence Infrastructure — Plan 113-05: Contradiction Detection
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `detect_contradictions(new_claim_text, *, entity_id, threshold=0.85)` and auto-call it from `write_claim` when `embed=True` so newly-written claims auto-populate their `contradicts` JSONB column with the UUIDs of existing high-similarity claims about the same entity that may say something different.
+
+**Architecture:** Embedding-similarity-only detection. Cosine distance via pgvector against existing claims tagged to the same entity. Threshold tuned to balance noise vs. catching real conflicts. Performance budget: adds ≤150ms to `write_claim` p95. Cross-agent value: Data's "Q1 retention = 62%" vs Research's "industry Q1 retention ≈ 71%" gets flagged automatically.
+
+**Tech Stack:** pgvector (same backend as Plan 113-04's semantic search), `app/services/intelligence/claims.py` (extended).
+
+**Spec reference:** `docs/superpowers/specs/2026-05-18-shared-intelligence-infra-design.md` § Phase 113 § Contradiction detection
+
+**Out of scope:** Semantic *interpretation* of whether two claims actually contradict (vs. just say similar things) — that requires LLM-in-the-loop and is deferred; this plan ships embedding-similarity flagging as a useful proxy. Per the spec, false-positive rate target is ≤10% on a hand-curated 50-pair test set.
+
+---
+
+## File structure
+
+**Create:**
+- `tests/unit/services/intelligence/test_contradictions.py` — unit tests with synthetic embeddings
+- `tests/integration/test_intelligence_contradictions.py` — integration tests with real pgvector
+- `tests/fixtures/contradiction_pairs.json` — 50 hand-curated `(claim_a, claim_b, should_flag)` pairs for tuning
+
+**Modify:**
+- `app/services/intelligence/claims.py` — add `detect_contradictions` + auto-populate path in `write_claim`
+- `app/services/intelligence/__init__.py` — re-export
+
+---
+
+## Pre-flight context
+
+`detect_contradictions` signature:
+```python
+async def detect_contradictions(
+    new_claim_text: str,
+    *,
+    entity_id: UUID,
+    threshold: float = 0.85,
+) -> list[UUID]
+```
+
+Returns UUIDs of EXISTING `kg_findings` rows attached to `entity_id` whose embedding cosine similarity to the new claim is `>= threshold`. The high threshold (0.85) is deliberate: we want only strong matches that could plausibly contradict, not loose neighbours.
+
+**Why this is a useful proxy** (and not the full thing): two claims with cosine similarity 0.9 are *about the same topic* — they may agree or disagree. The flag prompts human review; it doesn't assert disagreement. False positives are claims that say the same thing in different words. False negatives are claims that contradict by stating different numbers but use different phrasings entirely.
+
+The fix for the limitation is LLM-in-the-loop verification, deferred to a later plan.
+
+Acceptance bar (from spec):
+- Synthetic test: Data "Q1 retention = 62%" + Research "industry Q1 retention 71%" → Data's `contradicts` field auto-populates with Research's UUID
+- False-positive rate ≤10% on 50-pair hand-curated test set (Task 4)
+- Adds ≤150ms to `write_claim` p95 (Task 5)
+- Auto-call from `write_claim` only when `embed=True` (no embedding = no comparison vector)
+
+Environment quirks: same as prior plans.
+
+---
+
+## Tasks
+
+### Task 1: Pre-flight + create the hand-curated test set
+
+**Files:**
+- Create: `tests/fixtures/contradiction_pairs.json`
+
+- [ ] **Step 1: Confirm prerequisites**
+
+```bash
+grep -E "^async def (write_claim|search_claims_semantic)" app/services/intelligence/claims.py
+ls supabase/migrations/20260519000000_kg_findings_embedding_ivfflat_index.sql
+```
+
+Expected: both present.
+
+- [ ] **Step 2: Create `tests/fixtures/contradiction_pairs.json`**
+
+50 pairs of `(claim_a, claim_b, should_flag)`. Half should be "should_flag=true" (real contradictions / strong matches), half "should_flag=false" (different topics or harmless paraphrases that shouldn't trip the flag). Aim for a mix of:
+
+- Numerical conflicts (e.g., "Q1 retention 62%" vs "Q1 retention 71%") → should_flag=true
+- Directional conflicts (e.g., "revenue up" vs "revenue down") → should_flag=true
+- Paraphrases (e.g., "customers churned in Q1" vs "Q1 saw customer churn") → should_flag=false (same idea, no contradiction)
+- Different topics (e.g., "GDPR Article 17" vs "Q4 cohort retention") → should_flag=false
+
+```json
+[
+  {
+    "id": "p001",
+    "claim_a": "Q1 2026 customer retention dropped to 62%",
+    "claim_b": "Q1 2026 customer retention held at 71%",
+    "should_flag": true,
+    "reason": "Same period, conflicting numbers"
+  },
+  {
+    "id": "p002",
+    "claim_a": "Q1 revenue trended upward against the baseline",
+    "claim_b": "Q1 revenue declined month-over-month",
+    "should_flag": true,
+    "reason": "Same period, conflicting direction"
+  },
+  {
+    "id": "p003",
+    "claim_a": "Customers churned in Q1 due to pricing changes",
+    "claim_b": "Q1 saw elevated customer churn driven by pricing",
+    "should_flag": false,
+    "reason": "Paraphrase, agreement"
+  },
+  {
+    "id": "p004",
+    "claim_a": "GDPR Article 17 mandates erasure on request",
+    "claim_b": "Q4 cohort retention was 58%",
+    "should_flag": false,
+    "reason": "Different topics"
+  }
+  // ... add 46 more pairs covering the numerical / directional /
+  // paraphrase / different-topic categories with realistic phrasings
+]
+```
+
+Fill out the remaining 46 pairs. Don't make them too synthetic — use phrasings that resemble what `cohort_analysis`, `query_analytics`, etc. actually produce.
+
+- [ ] **Step 3: Commit the fixture**
+
+```bash
+git add tests/fixtures/contradiction_pairs.json
+git commit -m "test(113-05): hand-curated 50-pair fixture for contradiction tuning"
+```
+
+### Task 2: Implement `detect_contradictions` (TDD)
+
+**Files:**
+- Create: `tests/unit/services/intelligence/test_contradictions.py`
+- Modify: `app/services/intelligence/claims.py`
+- Modify: `app/services/intelligence/__init__.py`
+
+- [ ] **Step 1: Failing unit tests**
+
+```python
+"""Unit tests for detect_contradictions with mocked embedding + DB."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_returns_high_similarity_uuids():
+    """Rows above threshold are returned as contradicting candidates."""
+    from app.services.intelligence.claims import detect_contradictions
+
+    entity = uuid4()
+    similar_id = uuid4()
+    dissimilar_id = uuid4()
+    fake_rows = [
+        {"id": str(similar_id), "similarity": 0.05},  # very close (0.05 distance)
+        {"id": str(dissimilar_id), "similarity": 0.50},  # far
+    ]
+
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=[0.1] * 768),
+    ), patch(
+        "app.services.intelligence.claims._contradiction_query_rows",
+        new=AsyncMock(return_value=fake_rows),
+    ):
+        # threshold 0.85 means: similarity (= 1 - distance) >= 0.85,
+        # so distance <= 0.15. Only similar_id qualifies.
+        result = await detect_contradictions(
+            "Q1 retention = 62%", entity_id=entity, threshold=0.85,
+        )
+
+    assert similar_id in result
+    assert dissimilar_id not in result
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_no_embedding_returns_empty():
+    """If embedding generation fails, return [] (degrade silently)."""
+    from app.services.intelligence.claims import detect_contradictions
+
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await detect_contradictions(
+            "anything", entity_id=uuid4(),
+        )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_filters_by_entity():
+    """Only rows attached to the entity are considered."""
+    from app.services.intelligence.claims import detect_contradictions
+
+    captured = {}
+
+    async def capture_query(*, embedding, entity_id):
+        captured["entity_id"] = entity_id
+        return []
+
+    entity = uuid4()
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=[0.1] * 768),
+    ), patch(
+        "app.services.intelligence.claims._contradiction_query_rows",
+        side_effect=capture_query,
+    ):
+        await detect_contradictions("x", entity_id=entity)
+
+    assert captured["entity_id"] == entity
+```
+
+- [ ] **Step 2: Run — should FAIL**
+
+```powershell
+uv run pytest tests/unit/services/intelligence/test_contradictions.py -v --tb=short
+```
+
+- [ ] **Step 3: Implement in `claims.py`**
+
+Append:
+
+```python
+async def detect_contradictions(
+    new_claim_text: str,
+    *,
+    entity_id: UUID,
+    threshold: float = 0.85,
+) -> list[UUID]:
+    """Find existing claims about the same entity that may contradict the new one.
+
+    Strategy: embed the new claim, compare against existing claims attached
+    to the same entity via pgvector cosine distance. Return UUIDs of rows
+    whose similarity (1 - distance) >= threshold.
+
+    Read-degrades silently: embedding failure or DB failure returns [].
+
+    Note: this is an *embedding-similarity* signal, not semantic
+    interpretation. Two claims with similarity 0.9 are about the same
+    topic — they may agree or disagree. The flag prompts human review.
+    """
+    if not new_claim_text or len(new_claim_text.strip()) < 20:
+        return []
+
+    embedding = await _embed_text(new_claim_text)
+    if embedding is None:
+        return []
+
+    try:
+        rows = await _contradiction_query_rows(
+            embedding=embedding,
+            entity_id=entity_id,
+        )
+    except Exception as e:
+        logger.warning("detect_contradictions query failed: %s", e)
+        return []
+
+    matches: list[UUID] = []
+    for r in rows:
+        # similarity column from the SQL is the COSINE DISTANCE (0 = identical,
+        # 2 = opposite). similarity = 1 - distance. Distance <= (1 - threshold).
+        distance = float(r.get("similarity", 1.0))
+        similarity_score = 1.0 - distance
+        if similarity_score >= threshold:
+            try:
+                matches.append(UUID(r["id"]))
+            except (KeyError, ValueError):
+                continue
+    return matches
+
+
+async def _contradiction_query_rows(
+    *,
+    embedding: list[float],
+    entity_id: UUID,
+) -> list[dict]:
+    """Fetch (id, distance) pairs for existing claims on the same entity.
+
+    Limited to top 20 by distance so we don't scan unbounded rows.
+    """
+    import asyncio
+    import os
+    import psycopg
+
+    dsn = os.environ.get("SUPABASE_DB_URL") or os.environ.get("DATABASE_URL")
+    if not dsn:
+        return []
+
+    sql = """
+        SELECT id, (embedding <=> $1) AS similarity
+          FROM kg_findings
+         WHERE entity_id = $2
+           AND embedding IS NOT NULL
+         ORDER BY embedding <=> $1
+         LIMIT 20
+    """
+
+    def _run():
+        with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+            cur.execute(sql, (embedding, str(entity_id)))
+            cols = [d[0] for d in cur.description]
+            return [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
+
+    return await asyncio.get_event_loop().run_in_executor(None, _run)
+```
+
+Then update `__init__.py` to re-export `detect_contradictions`.
+
+- [ ] **Step 4: Re-run — should PASS**
+
+```powershell
+uv run pytest tests/unit/services/intelligence/test_contradictions.py -v --tb=short
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/intelligence/claims.py app/services/intelligence/__init__.py tests/unit/services/intelligence/test_contradictions.py
+git commit -m "feat(113-05): implement detect_contradictions with pgvector similarity (GREEN)"
+```
+
+### Task 3: Auto-populate `contradicts` in `write_claim` when `embed=True`
+
+**Files:**
+- Modify: `app/services/intelligence/claims.py` — `write_claim` calls `detect_contradictions` when `embed=True`
+
+- [ ] **Step 1: Modify `write_claim`** to call `detect_contradictions` after embedding generation and before insert:
+
+```python
+async def write_claim(
+    *,
+    entity_id: UUID | None,
+    edge_id: UUID | None = None,
+    domain: str,
+    finding_text: str,
+    confidence: float,
+    sources: Sequence[dict],
+    agent_id: str,
+    claim_type: str,
+    embed: bool = False,
+    expires_at: datetime | None = None,
+    contradicts: Sequence[UUID] = (),
+) -> UUID:
+    """[... existing docstring ...]"""
+    client = _get_supabase_client()
+
+    embedding: list[float] | None = None
+    auto_contradicts: list[UUID] = []
+    if embed and finding_text and len(finding_text) >= 20:
+        embedding = await _embed_text(finding_text)
+        # Auto-populate contradicts for entity-attached claims — only meaningful
+        # when we have an embedding to compare. Skip silently on errors.
+        if embedding is not None and entity_id is not None:
+            try:
+                auto_contradicts = await detect_contradictions(
+                    finding_text, entity_id=entity_id,
+                )
+            except Exception as e:
+                logger.warning("auto-detect_contradictions failed: %s", e)
+
+    # Merge caller-supplied and auto-detected contradicts (dedupe)
+    all_contradicts = list({*contradicts, *auto_contradicts})
+
+    row: dict = {
+        "domain": domain,
+        "finding_text": finding_text,
+        "confidence": confidence,
+        "sources": list(sources),
+        "contradicts": [str(c) for c in all_contradicts],
+        "agent_id": agent_id,
+        "claim_type": claim_type,
+    }
+    # [... rest of the existing implementation ...]
+```
+
+The change is localized: the existing function gains an `auto_contradicts` computation between embedding generation and the row build, and the row's `contradicts` column merges caller-supplied + auto-detected.
+
+- [ ] **Step 2: Write the integration test** in `tests/integration/test_intelligence_contradictions.py`:
+
+```python
+"""Integration test: cross-agent claims auto-populate contradicts."""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var) for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="env not set",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_conflicting_claims_auto_flag():
+    """Data's Q1 retention claim should flag Research's contradicting claim."""
+    from app.services.intelligence import (
+        find_claims, get_or_create_entity, write_claim,
+    )
+
+    e = await get_or_create_entity(
+        canonical_name=f"contradiction_q1_{uuid4()}",
+        entity_type="metric", domains=["data", "research"],
+    )
+
+    # Research writes the industry baseline first
+    research_id = await write_claim(
+        entity_id=e, domain="research",
+        finding_text="Industry Q1 2026 customer retention averaged 71 percent across benchmarks",
+        confidence=0.8,
+        sources=[{"kind": "url", "ref": "https://example.com/industry-report"}],
+        agent_id="research", claim_type="research_finding",
+        embed=True,
+    )
+
+    # Data writes the company-specific claim — should auto-detect the
+    # research claim as a contradicting candidate
+    data_id = await write_claim(
+        entity_id=e, domain="data",
+        finding_text="Q1 2026 customer retention dropped to 62 percent at our company",
+        confidence=0.85,
+        sources=[{"kind": "stripe_row", "ref": "test"}],
+        agent_id="data", claim_type="cohort_summary",
+        embed=True,
+    )
+
+    # Inspect the data claim's contradicts field
+    data_claim = (await find_claims(entity_id=e, limit=10))
+    target = next((c for c in data_claim if c.id == data_id), None)
+    assert target is not None
+    # The research claim should be in contradicts
+    assert research_id in target.contradicts, (
+        f"Expected research claim {research_id} in contradicts, "
+        f"got {target.contradicts}"
+    )
+```
+
+- [ ] **Step 3: Run**
+
+```powershell
+$env:SUPABASE_URL = "http://127.0.0.1:54321"
+$env:SUPABASE_SERVICE_ROLE_KEY = (supabase status -o env | Select-String '^SERVICE_ROLE_KEY=').ToString().Split('=',2)[1].Trim('"')
+$env:SUPABASE_DB_URL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+uv run pytest tests/integration/test_intelligence_contradictions.py -v --tb=short
+```
+
+Expected: PASS. If the research claim is NOT flagged, the similarity may be below 0.85 — investigate the actual cosine distance and adjust the test phrasings to be unambiguously similar.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/services/intelligence/claims.py tests/integration/test_intelligence_contradictions.py
+git commit -m "feat(113-05): auto-populate contradicts on write_claim when embed=True (GREEN)"
+```
+
+### Task 4: Tune the threshold against the hand-curated fixture
+
+**Files:**
+- Create: `tests/integration/test_contradiction_threshold_tuning.py`
+
+The 0.85 default may need adjustment based on the fixture's actual behavior.
+
+- [ ] **Step 1: Write the tuning test**
+
+```python
+"""Threshold-tuning test against the hand-curated contradiction fixture.
+
+Reports false-positive rate at threshold 0.85. Acceptance: <= 10%.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var) for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="env not set",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_threshold_tuning_at_default_0_85():
+    """At threshold 0.85: false-positive rate <= 10% on the 50-pair fixture."""
+    from app.services.intelligence import get_or_create_entity, write_claim
+    from app.services.intelligence.claims import detect_contradictions
+
+    fixture_path = Path("tests/fixtures/contradiction_pairs.json")
+    pairs = json.loads(fixture_path.read_text())
+
+    # For each pair: seed claim_a, then detect against claim_b text
+    false_positives = 0
+    false_negatives = 0
+    true_positives = 0
+    true_negatives = 0
+    should_flag_count = sum(1 for p in pairs if p["should_flag"])
+    should_not_flag_count = len(pairs) - should_flag_count
+
+    for pair in pairs:
+        entity = await get_or_create_entity(
+            canonical_name=f"tune_{pair['id']}_{uuid4()}",
+            entity_type="topic", domains=["test"],
+        )
+        # Write claim_a as the seed
+        await write_claim(
+            entity_id=entity, domain="test",
+            finding_text=pair["claim_a"],
+            confidence=0.5, sources=[],
+            agent_id="test", claim_type="probe",
+            embed=True,
+        )
+        # Run detection against claim_b
+        detected = await detect_contradictions(
+            pair["claim_b"], entity_id=entity, threshold=0.85,
+        )
+        flagged = len(detected) > 0
+
+        if pair["should_flag"] and flagged:
+            true_positives += 1
+        elif pair["should_flag"] and not flagged:
+            false_negatives += 1
+        elif not pair["should_flag"] and flagged:
+            false_positives += 1
+            print(f"FALSE POSITIVE on {pair['id']}: {pair['reason']}")
+        else:
+            true_negatives += 1
+
+    fp_rate = false_positives / max(1, should_not_flag_count)
+    fn_rate = false_negatives / max(1, should_flag_count)
+
+    print(f"TP={true_positives} FP={false_positives} FN={false_negatives} TN={true_negatives}")
+    print(f"FP rate (target <= 0.10): {fp_rate:.2%}")
+    print(f"FN rate (informational, no target): {fn_rate:.2%}")
+
+    assert fp_rate <= 0.10, (
+        f"False-positive rate {fp_rate:.2%} exceeds 10% target. "
+        f"Increase threshold above 0.85 to be more conservative."
+    )
+```
+
+- [ ] **Step 2: Run**
+
+```powershell
+uv run pytest tests/integration/test_contradiction_threshold_tuning.py -v
+```
+
+Expected: PASS at threshold 0.85. If FP rate > 10%, the test will fail and print the failing pairs — bump the threshold (try 0.88, 0.90) and update the default in `detect_contradictions` if needed.
+
+- [ ] **Step 3: If the default was changed, commit both the threshold change and the tuning test**
+
+```bash
+git add app/services/intelligence/claims.py tests/integration/test_contradiction_threshold_tuning.py
+git commit -m "feat(113-05): tune contradiction threshold to ${ACTUAL_VALUE}, <=10% FP rate on 50-pair fixture"
+```
+
+Otherwise commit only the test:
+
+```bash
+git add tests/integration/test_contradiction_threshold_tuning.py
+git commit -m "test(113-05): threshold-tuning test against 50-pair fixture (<=10% FP)"
+```
+
+### Task 5: Performance test — `write_claim` p95 budget
+
+**Files:**
+- Create: `tests/integration/test_write_claim_with_contradictions_perf.py`
+
+The spec budgets ≤150ms for the additional contradiction check on `write_claim` p95.
+
+- [ ] **Step 1: Write the perf test**
+
+```python
+"""Perf test: write_claim with embed=True + auto-contradiction stays under budget."""
+
+from __future__ import annotations
+
+import os
+import time
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var) for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="env not set",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_write_claim_embed_true_p95_under_budget():
+    """20 writes of embed=True claims; p95 latency <= 750ms (rough end-to-end)."""
+    from app.services.intelligence import get_or_create_entity, write_claim
+
+    entity = await get_or_create_entity(
+        canonical_name=f"perf_test_{uuid4()}",
+        entity_type="topic", domains=["test"],
+    )
+
+    # Seed some existing claims so contradiction-detect has rows to compare
+    for i in range(5):
+        await write_claim(
+            entity_id=entity, domain="test",
+            finding_text=f"Baseline observation {i}: stable behavior across cohorts",
+            confidence=0.5, sources=[],
+            agent_id="test", claim_type="probe",
+            embed=True,
+        )
+
+    latencies_ms = []
+    for i in range(20):
+        start = time.perf_counter()
+        await write_claim(
+            entity_id=entity, domain="test",
+            finding_text=f"New observation {i}: behavior changed in recent window",
+            confidence=0.6, sources=[],
+            agent_id="test", claim_type="probe",
+            embed=True,
+        )
+        latencies_ms.append((time.perf_counter() - start) * 1000)
+
+    latencies_ms.sort()
+    p95 = latencies_ms[int(len(latencies_ms) * 0.95)]
+    print(f"p50={latencies_ms[10]:.1f}ms p95={p95:.1f}ms (n={len(latencies_ms)})")
+
+    # 750ms p95 budget includes:
+    # - embedding generation (~100-200ms)
+    # - contradiction detection pgvector query (~50-100ms)
+    # - row insert (~50-100ms)
+    # - cumulative network/JSON overhead
+    # If this fails, the contradiction check is the most likely culprit
+    # (it's the new addition).
+    assert p95 <= 750, f"p95={p95:.0f}ms exceeds 750ms budget"
+```
+
+- [ ] **Step 2: Run**
+
+```powershell
+uv run pytest tests/integration/test_write_claim_with_contradictions_perf.py -v
+```
+
+Expected: PASS. If p95 exceeds budget, options:
+1. Skip the contradiction check on small text (already done via `len < 20` guard)
+2. Cap `_contradiction_query_rows` LIMIT lower than 20 (e.g., 10)
+3. Skip the check for non-entity claims (already done — only runs when `entity_id is not None`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_write_claim_with_contradictions_perf.py
+git commit -m "test(113-05): p95 perf test for write_claim with auto-contradiction"
+```
+
+### Task 6: Lint + Phase 113 acceptance sign-off
+
+- [ ] **Step 1: Lint**
+
+```powershell
+uv run ruff check app/services/intelligence/ tests/unit/services/intelligence/test_contradictions.py tests/integration/test_intelligence_contradictions.py tests/integration/test_contradiction_threshold_tuning.py tests/integration/test_write_claim_with_contradictions_perf.py
+uv run ruff format app/services/intelligence/ tests/unit/services/intelligence/test_contradictions.py tests/integration/test_intelligence_contradictions.py tests/integration/test_contradiction_threshold_tuning.py tests/integration/test_write_claim_with_contradictions_perf.py --check
+```
+
+Fix in place. Commit any fixes.
+
+- [ ] **Step 2: Phase 113 acceptance — cross-check ALL plans 113-01 through 113-05**
+
+| Phase 113 acceptance line | Verified by |
+|---|---|
+| `data_confidence` preset shipped | Plan 113-01 |
+| `cohort_analysis` carries `confidence` + `band` | Plan 113-01 |
+| Two-tier cache wired around Data Agent | Plan 113-02 |
+| Stripe call rate reduced ≥40% on repeated load | Plan 113-02 perf test |
+| `cohort_summary` + `cohort_retention_mN` claims emitted | Plan 113-03 |
+| Claim-type vocabulary documented | Plan 113-03 |
+| Graph-tier hit rate ≥60% on repeat | Plan 113-03 |
+| `search_claims_semantic` shipped | Plan 113-04 |
+| pgvector index used | Plan 113-04 EXPLAIN check |
+| Executive ADK tool `search_agent_claims` registered | Plan 113-04 |
+| `detect_contradictions` shipped | This plan |
+| Auto-populate on `write_claim` when `embed=True` | Task 3 |
+| FP rate ≤10% on hand-curated fixture | Task 4 |
+| `write_claim` p95 ≤150ms additional cost | Task 5 |
+
+- [ ] **Step 3: Plan 113-05 complete. Phase 113 (Data Agent adoption) is fully shipped.**
+
+Next planned work: other 8 specialized agents adopt the shared infrastructure in separate phases, prioritized by user value. Consolidation of `graph_service.py` / `intelligence_scheduler.py` / `intelligence_worker.py` into the `app/services/intelligence/` package is a separate cleanup phase.
+
+---
+
+## Spec coverage check
+
+| Spec requirement | Task(s) |
+|---|---|
+| `detect_contradictions(new_claim_text, entity_id, threshold)` | Task 2 |
+| Embedding-similarity-based | Task 2 + `_contradiction_query_rows` |
+| Auto-populates on `write_claim` when `embed=True` | Task 3 |
+| Cross-agent example (Data 62% / Research 71%) flagged | Task 3 integration test |
+| FP rate ≤10% on 50-pair hand-curated fixture | Tasks 1, 4 |
+| `write_claim` adds ≤150ms p95 | Task 5 |
+| Reads degrade silently on embedding failure | Task 2 + `test_detect_contradictions_no_embedding_returns_empty` |
+| Public surface re-exported | Task 2 Step 3 |
+| Lint clean | Task 6 |
+
+All spec lines covered.

--- a/supabase/migrations/20260519000000_kg_findings_embedding_ivfflat_index.sql
+++ b/supabase/migrations/20260519000000_kg_findings_embedding_ivfflat_index.sql
@@ -1,0 +1,6 @@
+BEGIN;
+CREATE INDEX IF NOT EXISTS idx_kg_findings_embedding_semantic
+    ON kg_findings USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 100);
+ANALYZE kg_findings;
+COMMIT;

--- a/tests/fixtures/contradiction_pairs.json
+++ b/tests/fixtures/contradiction_pairs.json
@@ -1,0 +1,352 @@
+[
+  {
+    "id": "p001",
+    "claim_a": "Q1 2026 customer retention dropped to 62%",
+    "claim_b": "Q1 2026 customer retention held at 71%",
+    "should_flag": true,
+    "reason": "Same period, conflicting numbers"
+  },
+  {
+    "id": "p002",
+    "claim_a": "Q1 revenue trended upward against the baseline",
+    "claim_b": "Q1 revenue declined month-over-month",
+    "should_flag": true,
+    "reason": "Same period, conflicting direction"
+  },
+  {
+    "id": "p003",
+    "claim_a": "Customers churned in Q1 due to pricing changes",
+    "claim_b": "Q1 saw elevated customer churn driven by pricing",
+    "should_flag": false,
+    "reason": "Paraphrase, agreement"
+  },
+  {
+    "id": "p004",
+    "claim_a": "GDPR Article 17 mandates erasure on request",
+    "claim_b": "Q4 cohort retention was 58%",
+    "should_flag": false,
+    "reason": "Different topics"
+  },
+  {
+    "id": "p005",
+    "claim_a": "Monthly active users in March 2026 reached 14,200",
+    "claim_b": "March 2026 monthly active users totaled 11,800",
+    "should_flag": true,
+    "reason": "Same month, conflicting MAU numbers"
+  },
+  {
+    "id": "p006",
+    "claim_a": "Average revenue per account grew 18% year-over-year in Q1 2026",
+    "claim_b": "Average revenue per account shrank 7% year-over-year in Q1 2026",
+    "should_flag": true,
+    "reason": "Same period and metric, opposing growth direction"
+  },
+  {
+    "id": "p007",
+    "claim_a": "Net promoter score improved to 42 following the Q4 product update",
+    "claim_b": "After the Q4 product update, NPS fell to 28",
+    "should_flag": true,
+    "reason": "Same trigger event, conflicting NPS outcome"
+  },
+  {
+    "id": "p008",
+    "claim_a": "Support ticket volume increased by 23% in February",
+    "claim_b": "February support ticket volume rose 23% compared to January",
+    "should_flag": false,
+    "reason": "Paraphrase of identical finding"
+  },
+  {
+    "id": "p009",
+    "claim_a": "The enterprise tier accounted for 61% of total ARR in Q1",
+    "claim_b": "Enterprise customers made up 61% of annual recurring revenue in Q1",
+    "should_flag": false,
+    "reason": "Paraphrase with same number"
+  },
+  {
+    "id": "p010",
+    "claim_a": "Data residency regulations in the EU require local storage for PII",
+    "claim_b": "Q2 cohort 30-day activation rate was 44%",
+    "should_flag": false,
+    "reason": "Completely different topics: compliance vs cohort metric"
+  },
+  {
+    "id": "p011",
+    "claim_a": "Churn rate for the SMB segment reached 4.2% in Q2 2026",
+    "claim_b": "SMB segment churn was only 1.8% for Q2 2026",
+    "should_flag": true,
+    "reason": "Same segment and period, conflicting churn numbers"
+  },
+  {
+    "id": "p012",
+    "claim_a": "Gross margin expanded to 74% in the most recent quarter",
+    "claim_b": "Gross margin compressed to 68% in the most recent quarter",
+    "should_flag": true,
+    "reason": "Same period, opposing gross margin direction"
+  },
+  {
+    "id": "p013",
+    "claim_a": "The onboarding completion rate for new signups was 81% in March",
+    "claim_b": "In March, 81% of new signups completed the onboarding flow",
+    "should_flag": false,
+    "reason": "Exact paraphrase, same meaning"
+  },
+  {
+    "id": "p014",
+    "claim_a": "Pipeline coverage at end of Q1 was 3.2x against quota",
+    "claim_b": "Q1 closed pipeline coverage ratio stood at 3.2x quota",
+    "should_flag": false,
+    "reason": "Paraphrase with same ratio"
+  },
+  {
+    "id": "p015",
+    "claim_a": "Employee headcount increased by 12 in Q1, bringing total to 87",
+    "claim_b": "API error rate averaged 0.04% across production in Q1",
+    "should_flag": false,
+    "reason": "Different topics: HR headcount vs infrastructure error rate"
+  },
+  {
+    "id": "p016",
+    "claim_a": "Median deal size for new logos was $8,400 in Q1 2026",
+    "claim_b": "New logo median deal size was $12,100 in Q1 2026",
+    "should_flag": true,
+    "reason": "Same period and segment, conflicting deal size"
+  },
+  {
+    "id": "p017",
+    "claim_a": "Customer acquisition cost fell to $340 per new customer in Q2",
+    "claim_b": "Q2 customer acquisition cost rose to $510 per new customer",
+    "should_flag": true,
+    "reason": "Same period and metric, opposite direction"
+  },
+  {
+    "id": "p018",
+    "claim_a": "Sales cycle length shortened from 47 days to 32 days in Q1",
+    "claim_b": "Average sales cycle lengthened from 47 days to 61 days in Q1",
+    "should_flag": true,
+    "reason": "Same starting point, conflicting outcome"
+  },
+  {
+    "id": "p019",
+    "claim_a": "Time-to-value for new customers improved to under 14 days",
+    "claim_b": "New customers achieved value in fewer than 14 days on average",
+    "should_flag": false,
+    "reason": "Paraphrase, same finding"
+  },
+  {
+    "id": "p020",
+    "claim_a": "Stripe webhook processing latency averaged 180ms in Q1",
+    "claim_b": "HR onboarding paperwork cycle time averaged 3.4 business days in Q1",
+    "should_flag": false,
+    "reason": "Different domains: infrastructure vs HR operations"
+  },
+  {
+    "id": "p021",
+    "claim_a": "Product-qualified lead conversion rate increased to 28% in Q2",
+    "claim_b": "PQL-to-customer conversion rate dropped to 14% in Q2",
+    "should_flag": true,
+    "reason": "Same funnel stage and period, conflicting conversion numbers"
+  },
+  {
+    "id": "p022",
+    "claim_a": "Cohort 2025-Q4 reached 90-day retention of 76%",
+    "claim_b": "The Q4 2025 cohort had 59% retention at the 90-day mark",
+    "should_flag": true,
+    "reason": "Same cohort and horizon, conflicting retention numbers"
+  },
+  {
+    "id": "p023",
+    "claim_a": "Feature adoption for the analytics dashboard was 38% among active accounts",
+    "claim_b": "Analytics dashboard adoption among active accounts stood at 38%",
+    "should_flag": false,
+    "reason": "Paraphrase, identical finding"
+  },
+  {
+    "id": "p024",
+    "claim_a": "CCPA compliance audit found no material deficiencies in Q1 2026",
+    "claim_b": "Q1 2026 cohort day-30 reactivation rate was 9%",
+    "should_flag": false,
+    "reason": "Different topics: compliance audit vs product reactivation metric"
+  },
+  {
+    "id": "p025",
+    "claim_a": "Revenue from expansion accounted for 34% of net new ARR in Q1",
+    "claim_b": "In Q1, expansion revenue contributed 34% of total new ARR",
+    "should_flag": false,
+    "reason": "Paraphrase with same statistic"
+  },
+  {
+    "id": "p026",
+    "claim_a": "The marketing team generated 1,240 MQLs in Q1 2026",
+    "claim_b": "Q1 2026 marketing qualified lead volume was 870",
+    "should_flag": true,
+    "reason": "Same period and metric, conflicting MQL count"
+  },
+  {
+    "id": "p027",
+    "claim_a": "Infrastructure uptime for the core API was 99.94% over Q1",
+    "claim_b": "Core API availability dropped to 99.71% during Q1",
+    "should_flag": true,
+    "reason": "Same system and period, conflicting uptime figures"
+  },
+  {
+    "id": "p028",
+    "claim_a": "Customer success headcount grew from 8 to 11 in the quarter",
+    "claim_b": "CS team expanded by 3 headcount in the same quarter",
+    "should_flag": false,
+    "reason": "Paraphrase, same delta expressed differently"
+  },
+  {
+    "id": "p029",
+    "claim_a": "SOC 2 Type II certification was renewed without findings in January 2026",
+    "claim_b": "February gross merchandise volume grew 22% over prior month",
+    "should_flag": false,
+    "reason": "Different topics: compliance certification vs GMV metric"
+  },
+  {
+    "id": "p030",
+    "claim_a": "Win rate against Competitor A improved from 31% to 45% in H2 2025",
+    "claim_b": "Win rate versus Competitor A declined from 31% to 22% in H2 2025",
+    "should_flag": true,
+    "reason": "Same period and competitor, opposite win-rate direction"
+  },
+  {
+    "id": "p031",
+    "claim_a": "Engineering deployment frequency reached 12 deploys per week in Q1",
+    "claim_b": "Q1 deployment cadence averaged 12 releases per week",
+    "should_flag": false,
+    "reason": "Paraphrase with same frequency"
+  },
+  {
+    "id": "p032",
+    "claim_a": "Average contract value for upsells was $4,200 in Q2 2026",
+    "claim_b": "Upsell average contract value reached $7,600 in Q2 2026",
+    "should_flag": true,
+    "reason": "Same period and segment, conflicting ACV"
+  },
+  {
+    "id": "p033",
+    "claim_a": "ISO 27001 audit scheduled for June 2026 per the compliance calendar",
+    "claim_b": "Day-7 email open rate for onboarding sequence was 61% in Q1",
+    "should_flag": false,
+    "reason": "Different topics: compliance scheduling vs email marketing"
+  },
+  {
+    "id": "p034",
+    "claim_a": "Free-to-paid conversion rate dropped from 12% to 8% after the price increase",
+    "claim_b": "Free-to-paid conversion rate rose from 12% to 17% after the price increase",
+    "should_flag": true,
+    "reason": "Same event, opposite conversion direction"
+  },
+  {
+    "id": "p035",
+    "claim_a": "Total contracted ARR at end of Q1 was $2.4M",
+    "claim_b": "Contracted ARR stood at $2.4M at the end of Q1",
+    "should_flag": false,
+    "reason": "Paraphrase, identical ARR figure"
+  },
+  {
+    "id": "p036",
+    "claim_a": "Mean time to resolution for P1 incidents dropped to 42 minutes in Q1",
+    "claim_b": "P1 incident MTTR increased to 94 minutes in Q1",
+    "should_flag": true,
+    "reason": "Same severity and period, conflicting resolution time"
+  },
+  {
+    "id": "p037",
+    "claim_a": "The new sales playbook reduced ramp time for AEs by 3 weeks",
+    "claim_b": "Implementing the sales playbook extended AE ramp time by 2 weeks",
+    "should_flag": true,
+    "reason": "Same intervention, opposite effect on ramp time"
+  },
+  {
+    "id": "p038",
+    "claim_a": "Headcount in the data engineering team doubled from 4 to 8 in Q1",
+    "claim_b": "Data engineering team size grew from 4 to 8 people during Q1",
+    "should_flag": false,
+    "reason": "Paraphrase with identical headcount change"
+  },
+  {
+    "id": "p039",
+    "claim_a": "Vendor contract for cloud infrastructure expires in September 2026",
+    "claim_b": "Q1 gross revenue retention rate was 94%",
+    "should_flag": false,
+    "reason": "Different topics: procurement vs retention metric"
+  },
+  {
+    "id": "p040",
+    "claim_a": "Day-14 retention for the February cohort was 67%",
+    "claim_b": "February cohort day-14 retention came in at 48%",
+    "should_flag": true,
+    "reason": "Same cohort and horizon, conflicting retention numbers"
+  },
+  {
+    "id": "p041",
+    "claim_a": "Operating expenses as a percentage of revenue improved to 61% in Q1",
+    "claim_b": "Q1 operating expenses represented 61% of revenue",
+    "should_flag": false,
+    "reason": "Paraphrase, same opex-to-revenue ratio"
+  },
+  {
+    "id": "p042",
+    "claim_a": "Referral program generated 18% of new signups in Q1 2026",
+    "claim_b": "In Q1 2026, referrals accounted for 6% of new customer signups",
+    "should_flag": true,
+    "reason": "Same channel and period, conflicting share of signups"
+  },
+  {
+    "id": "p043",
+    "claim_a": "Sprint velocity for the platform squad averaged 48 story points in Q1",
+    "claim_b": "Platform squad averaged 48 story points per sprint during Q1",
+    "should_flag": false,
+    "reason": "Paraphrase, identical velocity figure"
+  },
+  {
+    "id": "p044",
+    "claim_a": "Payroll costs grew 9% quarter-over-quarter in Q1 2026",
+    "claim_b": "Q1 2026 payroll expenses declined 4% relative to Q4 2025",
+    "should_flag": true,
+    "reason": "Same metric and period, opposing growth direction"
+  },
+  {
+    "id": "p045",
+    "claim_a": "HIPAA breach notification policy was updated in February 2026",
+    "claim_b": "Q1 sales qualified leads increased 31% over Q4 2025",
+    "should_flag": false,
+    "reason": "Different topics: compliance policy vs sales pipeline metric"
+  },
+  {
+    "id": "p046",
+    "claim_a": "Session duration for dashboard users averaged 8.4 minutes in March",
+    "claim_b": "March dashboard session length averaged 8.4 minutes per user",
+    "should_flag": false,
+    "reason": "Paraphrase, same engagement metric"
+  },
+  {
+    "id": "p047",
+    "claim_a": "Expansion MRR from existing accounts was $42K in March 2026",
+    "claim_b": "March 2026 expansion MRR reached $67K from existing accounts",
+    "should_flag": true,
+    "reason": "Same month and category, conflicting MRR amount"
+  },
+  {
+    "id": "p048",
+    "claim_a": "Embedding generation p99 latency was under 200ms in production Q1",
+    "claim_b": "Q1 employee satisfaction score averaged 7.4 out of 10",
+    "should_flag": false,
+    "reason": "Different topics: system latency vs HR engagement score"
+  },
+  {
+    "id": "p049",
+    "claim_a": "Customer support CSAT score held at 4.6 out of 5 for Q1",
+    "claim_b": "Q1 customer support CSAT averaged 4.6 out of 5",
+    "should_flag": false,
+    "reason": "Paraphrase, same CSAT score"
+  },
+  {
+    "id": "p050",
+    "claim_a": "Revenue growth rate for Q1 2026 was 34% year-over-year",
+    "claim_b": "Year-over-year revenue growth slowed to 19% in Q1 2026",
+    "should_flag": true,
+    "reason": "Same period and metric, conflicting growth rate"
+  }
+]

--- a/tests/integration/test_contradiction_threshold_tuning.py
+++ b/tests/integration/test_contradiction_threshold_tuning.py
@@ -22,8 +22,7 @@ pytestmark = [
     pytest.mark.slow,
     pytest.mark.skipif(
         not all(
-            os.environ.get(var)
-            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+            os.environ.get(var) for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
         ),
         reason="env not set",
     ),

--- a/tests/integration/test_contradiction_threshold_tuning.py
+++ b/tests/integration/test_contradiction_threshold_tuning.py
@@ -1,0 +1,120 @@
+"""Threshold-tuning test against the hand-curated contradiction fixture.
+
+Reports false-positive rate at threshold 0.85. Acceptance: <= 10%.
+
+Requires a running local Supabase stack with real embedding credentials.
+When the embedding service is in zero-vector fallback mode, all cosine
+distances are NaN so no pairs are detected — the test skips automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="env not set",
+    ),
+]
+
+
+def _embeddings_available() -> bool:
+    """Return True only when the embedding service returns real (non-zero) vectors."""
+    from app.rag.embedding_service import generate_embedding
+
+    emb = generate_embedding("test")
+    return any(v != 0.0 for v in emb[:10])
+
+
+@pytest.mark.asyncio
+async def test_threshold_tuning_at_default_0_85():
+    """At threshold 0.85: false-positive rate <= 10% on the 50-pair fixture.
+
+    For each pair: seeds claim_a under a unique entity, then runs
+    detect_contradictions(claim_b, entity_id, threshold=0.85) and tallies
+    TP/FP/FN/TN. Skips when embeddings are in zero-vector fallback mode.
+    """
+    loop = asyncio.get_event_loop()
+    real_embeddings = await loop.run_in_executor(None, _embeddings_available)
+    if not real_embeddings:
+        pytest.skip(
+            "Embedding service in zero-vector fallback mode (no Google credentials). "
+            "Threshold tuning requires real embeddings. "
+            "Set GOOGLE_API_KEY or Vertex AI env vars and re-run."
+        )
+
+    from app.services.intelligence import get_or_create_entity, write_claim
+    from app.services.intelligence.claims import detect_contradictions
+
+    fixture_path = Path("tests/fixtures/contradiction_pairs.json")
+    pairs = json.loads(fixture_path.read_text())
+
+    false_positives = 0
+    false_negatives = 0
+    true_positives = 0
+    true_negatives = 0
+    should_flag_count = sum(1 for p in pairs if p["should_flag"])
+    should_not_flag_count = len(pairs) - should_flag_count
+
+    for pair in pairs:
+        entity = await get_or_create_entity(
+            canonical_name=f"tune_{pair['id']}_{uuid4()}",
+            entity_type="topic",
+            domains=["test"],
+        )
+        # Write claim_a as the seed
+        await write_claim(
+            entity_id=entity,
+            domain="test",
+            finding_text=pair["claim_a"],
+            confidence=0.5,
+            sources=[],
+            agent_id="test",
+            claim_type="probe",
+            embed=True,
+        )
+        # Run detection against claim_b text
+        detected = await detect_contradictions(
+            pair["claim_b"],
+            entity_id=entity,
+            threshold=0.85,
+        )
+        flagged = len(detected) > 0
+
+        if pair["should_flag"] and flagged:
+            true_positives += 1
+        elif pair["should_flag"] and not flagged:
+            false_negatives += 1
+            print(f"FALSE NEGATIVE on {pair['id']}: {pair['reason']}")
+        elif not pair["should_flag"] and flagged:
+            false_positives += 1
+            print(f"FALSE POSITIVE on {pair['id']}: {pair['reason']}")
+        else:
+            true_negatives += 1
+
+    fp_rate = false_positives / max(1, should_not_flag_count)
+    fn_rate = false_negatives / max(1, should_flag_count)
+
+    print(
+        f"\nTP={true_positives} FP={false_positives} "
+        f"FN={false_negatives} TN={true_negatives}"
+    )
+    print(f"FP rate (target <= 0.10): {fp_rate:.2%}")
+    print(f"FN rate (informational, no target): {fn_rate:.2%}")
+
+    assert fp_rate <= 0.10, (
+        f"False-positive rate {fp_rate:.2%} exceeds 10% target. "
+        f"Increase threshold above 0.85 to be more conservative."
+    )

--- a/tests/integration/test_data_cache_integration.py
+++ b/tests/integration/test_data_cache_integration.py
@@ -99,18 +99,31 @@ async def test_cohort_analysis_short_circuits_on_fresh_graph_claim():
 async def test_cohort_analysis_misses_graph_then_computes():
     """Without a fresh claim, cohort_analysis calls the service normally.
 
-    Uses months=99 (a value never seeded by other tests) so this test is
-    isolated from claim accumulation by the 113-03 emission tests.
+    Patches _cohort_entity_id to a brand-new UUID that has never had a claim,
+    guaranteeing a graph cache miss regardless of prior test runs.
     """
     from app.agents.data.tools import cohort_analysis
+    from app.services.intelligence import get_or_create_entity
 
+    # Create a unique entity that has no claims → graph cache will always miss
+    fresh_entity_id = await get_or_create_entity(
+        canonical_name=f"cohort_miss_test_{uuid4()}",
+        entity_type="metric",
+        domains=["data"],
+    )
     fake_service = _make_fake_service()
 
-    with patch(
-        "app.services.cohort_analysis_service.CohortAnalysisService",
-        return_value=fake_service,
+    with (
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.agents.data.tools._cohort_entity_id",
+            AsyncMock(return_value=fresh_entity_id),
+        ),
     ):
-        result = await cohort_analysis(months=99)
+        result = await cohort_analysis(months=6)
 
     fake_service.full_cohort_analysis.assert_called_once()
     assert "confidence" in result, f"Expected confidence in result: {result}"
@@ -262,6 +275,75 @@ async def test_cohort_analysis_writes_per_month_retention_claims():
     assert len(m1) >= 1, "cohort_retention_m1 claims should exist"
     assert len(m2) >= 1, "cohort_retention_m2 claims should exist"
     assert len(m3) >= 1, "cohort_retention_m3 claims should exist"
+
+
+@pytest.mark.asyncio
+async def test_second_cohort_call_hits_graph_cache():
+    """First cohort_analysis call writes claims; second call reads them and short-circuits.
+
+    Patches _cohort_entity_id to a fresh UUID so the graph cache is guaranteed
+    cold on the first call regardless of prior test runs. Both calls share the
+    same entity ID so the claim written by the first call is found by the second.
+    """
+    from app.agents.data.tools import cohort_analysis
+    from app.services.intelligence import get_or_create_entity
+
+    # Fresh entity — no existing claims, so first call definitely hits the service
+    fresh_entity_id = await get_or_create_entity(
+        canonical_name=f"cohort_loop_test_{uuid4()}",
+        entity_type="metric",
+        domains=["data"],
+    )
+
+    fake_service = AsyncMock()
+    fake_service.full_cohort_analysis = AsyncMock(return_value={
+        "retention": {
+            "cohorts": {
+                "2026-03": {"month_0": 100.0, "month_1": 90.0},
+            },
+            "months_analyzed": 6,
+            "total_customers": 100,
+        },
+        "ltv": {"cohorts": {}, "overall_avg_ltv": 0.0},
+        "churn": {"cohorts": {}, "overall_churn_rate": 0.0},
+        "executive_summary": "fresh test for graph cache loop",
+        "chart_data": {},
+    })
+
+    with (
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=fake_service,
+        ),
+        patch(
+            # Both calls share the same fresh entity ID: first call writes the
+            # claim, second call finds it and short-circuits.
+            "app.agents.data.tools._cohort_entity_id",
+            AsyncMock(return_value=fresh_entity_id),
+        ),
+    ):
+        # Cold call — graph cache misses (fresh entity, no claims), service hit,
+        # claims written by the new emission code.
+        first = await cohort_analysis(months=6)
+        assert first.get("from_cache", False) is False, (
+            f"Expected from_cache=False on cold call, got: {first}"
+        )
+        assert fake_service.full_cohort_analysis.call_count == 1
+
+        # Warm call — graph tier should find the freshly written cohort_summary
+        # claim and short-circuit without calling the service again.
+        second = await cohort_analysis(months=6)
+        assert second.get("from_cache") is True, (
+            f"Expected from_cache=True on warm call, got: {second}"
+        )
+        assert second.get("cache_tier") == "graph", (
+            f"Expected cache_tier='graph', got: {second}"
+        )
+        # Service must not have been called a second time
+        assert fake_service.full_cohort_analysis.call_count == 1, (
+            f"Service was called {fake_service.full_cohort_analysis.call_count} times; "
+            f"expected 1 (graph cache should have served second call)"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_data_cache_integration.py
+++ b/tests/integration/test_data_cache_integration.py
@@ -1,0 +1,177 @@
+"""Integration tests for Data Agent two-tier cache wiring (Plan 113-02).
+
+Requires local Supabase + Redis running with the Phase 112 migrations applied.
+Skip with: pytest -m "not integration"
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="Supabase credentials not provided in environment variables.",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Shared fake-service builder
+# ---------------------------------------------------------------------------
+
+_FAKE_FULL_RESULT = {
+    "retention": {"cohorts": {"2026-01": {"month_0": 100.0}}, "months_analyzed": 6, "total_customers": 150},
+    "ltv": {"cohorts": {}, "overall_avg_ltv": 0.0},
+    "churn": {"cohorts": {}, "overall_churn_rate": 0.0},
+    "executive_summary": "test summary",
+    "chart_data": {},
+}
+
+
+def _make_fake_service():
+    """Return a mock CohortAnalysisService whose full_cohort_analysis returns fake data."""
+    fake = AsyncMock()
+    fake.full_cohort_analysis = AsyncMock(return_value=_FAKE_FULL_RESULT)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Graph-tier short-circuit: when a fresh claim exists, skip computation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_short_circuits_on_fresh_graph_claim():
+    """If a fresh cohort_summary claim exists in kg_findings, cohort_analysis
+    returns from it without invoking CohortAnalysisService.
+    """
+    from app.services.intelligence import get_or_create_entity, write_claim
+
+    # Seed a fresh claim with a unique entity so it doesn't collide with other tests
+    entity_id = await get_or_create_entity(
+        canonical_name=f"cohort_test_{uuid4()}",
+        entity_type="metric",
+        domains=["data"],
+    )
+    await write_claim(
+        entity_id=entity_id,
+        domain="data",
+        finding_text="seeded cohort summary for short-circuit test",
+        confidence=0.85,
+        sources=[{"kind": "stripe_row", "ref": "test"}],
+        agent_id="data",
+        claim_type="cohort_summary",
+    )
+
+    fake_service = _make_fake_service()
+
+    with (
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=fake_service,
+        ),
+        patch(
+            # Redirect the entity-id derivation to our seeded entity so
+            # should_query_graph finds the claim we just wrote.
+            "app.agents.data.tools._cohort_entity_id",
+            AsyncMock(return_value=entity_id),
+        ),
+    ):
+        result = await _call_cohort_analysis()
+
+    # Service should NOT have been called — we returned from graph cache
+    fake_service.full_cohort_analysis.assert_not_called()
+    assert result.get("from_cache") is True, f"Expected from_cache=True, got: {result}"
+    assert result.get("cache_tier") == "graph"
+    # band should be present (derived from stored confidence = 0.85 → high)
+    assert result.get("band") == "high"
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_misses_graph_then_computes():
+    """Without a fresh claim, cohort_analysis calls the service normally."""
+    from app.agents.data.tools import cohort_analysis
+
+    fake_service = _make_fake_service()
+
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ):
+        result = await cohort_analysis(months=6)
+
+    fake_service.full_cohort_analysis.assert_called_once()
+    assert "confidence" in result, f"Expected confidence in result: {result}"
+    assert result.get("from_cache", False) is False
+
+
+# ---------------------------------------------------------------------------
+# Redis-tier: Stripe payload is cached so repeated calls don't re-hit DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stripe_payload_cached_in_redis():
+    """A repeated cohort_analysis call within the Redis TTL doesn't re-call
+    the underlying Stripe/DB fetch function.
+    """
+    from app.agents.data.tools import cohort_analysis
+
+    call_count = {"n": 0}
+
+    async def fake_stripe_fetch(months, user_id):
+        call_count["n"] += 1
+        return []  # empty rows — service returns no-customer result
+
+    fake_service = _make_fake_service()
+
+    with (
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.services.cohort_analysis_service._fetch_stripe_transactions",
+            side_effect=fake_stripe_fetch,
+        ),
+    ):
+        # First call — graph cache misses (no claim written); falls through to
+        # full_cohort_analysis mock.  Our patch of _fetch_stripe_transactions is
+        # overriding the cached wrapper itself, so call_count tracks invocations
+        # at the patching boundary.
+        await cohort_analysis(months=7)
+        first_count = call_count["n"]
+        # Second call within 300 s — the Redis tier should serve the cached result,
+        # NOT call _fetch_stripe_transactions again.
+        await cohort_analysis(months=7)
+        second_count = call_count["n"]
+
+    # Both calls go through full_cohort_analysis mock (graph miss for months=7),
+    # but the Stripe fetch inside each compute_* method should be cached after
+    # the first call.  The second full_cohort_analysis invocation (3 compute
+    # methods) should hit Redis for all 3 sub-calls.
+    assert second_count == first_count, (
+        f"Repeated cohort_analysis within TTL should not increment _fetch_stripe_transactions. "
+        f"first={first_count}, second={second_count}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _call_cohort_analysis(months: int = 6) -> dict:
+    """Import and call cohort_analysis, re-importing to pick up patches."""
+    # Re-import at call time so in-function local imports pick up patches
+    from app.agents.data.tools import cohort_analysis
+
+    return await cohort_analysis(months=months)

--- a/tests/integration/test_data_cache_integration.py
+++ b/tests/integration/test_data_cache_integration.py
@@ -97,7 +97,11 @@ async def test_cohort_analysis_short_circuits_on_fresh_graph_claim():
 
 @pytest.mark.asyncio
 async def test_cohort_analysis_misses_graph_then_computes():
-    """Without a fresh claim, cohort_analysis calls the service normally."""
+    """Without a fresh claim, cohort_analysis calls the service normally.
+
+    Uses months=99 (a value never seeded by other tests) so this test is
+    isolated from claim accumulation by the 113-03 emission tests.
+    """
     from app.agents.data.tools import cohort_analysis
 
     fake_service = _make_fake_service()
@@ -106,7 +110,7 @@ async def test_cohort_analysis_misses_graph_then_computes():
         "app.services.cohort_analysis_service.CohortAnalysisService",
         return_value=fake_service,
     ):
-        result = await cohort_analysis(months=6)
+        result = await cohort_analysis(months=99)
 
     fake_service.full_cohort_analysis.assert_called_once()
     assert "confidence" in result, f"Expected confidence in result: {result}"
@@ -162,6 +166,102 @@ async def test_stripe_payload_cached_in_redis():
         f"Repeated cohort_analysis within TTL should not increment _fetch_stripe_transactions. "
         f"first={first_count}, second={second_count}."
     )
+
+
+# ---------------------------------------------------------------------------
+# Plan 113-03: claim emission
+# ---------------------------------------------------------------------------
+
+# Fake full_cohort_analysis return value with real-shaped retention data
+# (retention.cohorts is a dict of cohort_month → {month_0: 100.0, month_N: X})
+_FAKE_FULL_RESULT_WITH_RETENTION = {
+    "retention": {
+        "cohorts": {
+            "2026-01": {"month_0": 100.0, "month_1": 85.0, "month_2": 72.0, "month_3": 65.0},
+        },
+        "months_analyzed": 6,
+        "total_customers": 200,
+    },
+    "ltv": {"cohorts": {}, "overall_avg_ltv": 0.0},
+    "churn": {"cohorts": {}, "overall_churn_rate": 0.0},
+    "executive_summary": "Stable retention in early cohorts.",
+    "chart_data": {},
+}
+
+_FAKE_FULL_RESULT_TWO_COHORTS = {
+    "retention": {
+        "cohorts": {
+            "2026-01": {"month_0": 100.0, "month_1": 85.0, "month_2": 72.0, "month_3": 65.0},
+            "2026-02": {"month_0": 100.0, "month_1": 88.0, "month_2": 74.0},
+        },
+        "months_analyzed": 6,
+        "total_customers": 380,
+    },
+    "ltv": {"cohorts": {}, "overall_avg_ltv": 0.0},
+    "churn": {"cohorts": {}, "overall_churn_rate": 0.0},
+    "executive_summary": "Two cohorts analysed; retention broadly stable.",
+    "chart_data": {},
+}
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_writes_summary_claim():
+    """After a fresh cohort_analysis, a cohort_summary claim exists in kg_findings."""
+    from app.agents.data.tools import _cohort_entity_id, cohort_analysis
+    from app.services.intelligence import find_claims
+
+    fake_service = AsyncMock()
+    fake_service.full_cohort_analysis = AsyncMock(
+        return_value=_FAKE_FULL_RESULT_WITH_RETENTION
+    )
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ):
+        await cohort_analysis(months=6)
+
+    entity_id = await _cohort_entity_id(6)
+    summaries = await find_claims(
+        entity_id=entity_id, claim_type="cohort_summary", agent_id="data", limit=5,
+    )
+    assert len(summaries) >= 1
+    assert summaries[0].finding_text  # non-empty
+    assert summaries[0].agent_id == "data"
+    assert summaries[0].domain == "data"
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_writes_per_month_retention_claims():
+    """After cohort_analysis, per-month retention claims exist (one per cohort × month)."""
+    from app.agents.data.tools import _cohort_entity_id, cohort_analysis
+    from app.services.intelligence import find_claims
+
+    fake_service = AsyncMock()
+    fake_service.full_cohort_analysis = AsyncMock(
+        return_value=_FAKE_FULL_RESULT_TWO_COHORTS
+    )
+    with patch(
+        "app.services.cohort_analysis_service.CohortAnalysisService",
+        return_value=fake_service,
+    ):
+        await cohort_analysis(months=6)
+
+    entity_id = await _cohort_entity_id(6)
+    # We seeded 4 + 3 = 7 (cohort, month) points across month_1..month_3 and month_1..month_2
+    # (month_0 = 100% acquisition month is intentionally skipped)
+    m1 = await find_claims(
+        entity_id=entity_id, claim_type="cohort_retention_m1", agent_id="data", limit=10,
+    )
+    m2 = await find_claims(
+        entity_id=entity_id, claim_type="cohort_retention_m2", agent_id="data", limit=10,
+    )
+    m3 = await find_claims(
+        entity_id=entity_id, claim_type="cohort_retention_m3", agent_id="data", limit=10,
+    )
+    # At least one of each — fixture-row uniqueness across runs may vary so use >=
+    assert len(m1) >= 1, "cohort_retention_m1 claims should exist"
+    assert len(m2) >= 1, "cohort_retention_m2 claims should exist"
+    assert len(m3) >= 1, "cohort_retention_m3 claims should exist"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_data_cache_integration.py
+++ b/tests/integration/test_data_cache_integration.py
@@ -245,7 +245,7 @@ async def test_cohort_analysis_writes_summary_claim():
 
 @pytest.mark.asyncio
 async def test_cohort_analysis_writes_per_month_retention_claims():
-    """After cohort_analysis, per-month retention claims exist (one per cohort × month)."""
+    """After cohort_analysis, per-month retention claims exist (one per cohort x month)."""
     from app.agents.data.tools import _cohort_entity_id, cohort_analysis
     from app.services.intelligence import find_claims
 

--- a/tests/integration/test_data_cache_load.py
+++ b/tests/integration/test_data_cache_load.py
@@ -1,0 +1,83 @@
+"""Synthetic load test: confirm Stripe call count is reduced by Plan 113-02 caching.
+
+Acceptance criterion from spec:
+    Stripe API call rate reduced by >= 40% vs pre-113 baseline during repeated
+    requests within the Redis TTL window.
+
+Implementation: 20 identical cohort_analysis(months=6) calls with a counting
+mock on _fetch_stripe_transactions. After the first cold call, Redis should
+serve all subsequent 19 requests — expected stripe_calls == 1, threshold <= 12.
+
+Requires local Supabase + Redis. Skip with: pytest -m "not integration"
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "REDIS_PASSWORD"]
+        ),
+        reason="env vars not provided",
+    ),
+]
+
+_FAKE_FULL_RESULT = {
+    "retention": {"cohorts": {"2026-01": {"month_0": 100.0}}, "months_analyzed": 6, "total_customers": 100},
+    "ltv": {"cohorts": {}, "overall_avg_ltv": 0.0},
+    "churn": {"cohorts": {}, "overall_churn_rate": 0.0},
+    "executive_summary": "load test summary",
+    "chart_data": {},
+}
+
+
+@pytest.mark.asyncio
+async def test_stripe_call_rate_below_60pct_of_request_count():
+    """Across 20 cohort_analysis(months=6) calls, _fetch_stripe_transactions is
+    invoked fewer than 12 times (>= 40% reduction vs the 20-call baseline).
+
+    Expected: stripe_calls == 1 (one cold call + 19 Redis hits within TTL).
+    Threshold: <= 12 (generous 40% reduction bar).
+    """
+    from app.agents.data.tools import cohort_analysis
+
+    fake_service = AsyncMock()
+    fake_service.full_cohort_analysis = AsyncMock(return_value=_FAKE_FULL_RESULT)
+
+    stripe_calls = 0
+
+    async def counting_stripe(months, user_id):
+        nonlocal stripe_calls
+        stripe_calls += 1
+        return []  # empty rows; service mock provides the full result
+
+    with (
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=fake_service,
+        ),
+        patch(
+            "app.services.cohort_analysis_service._fetch_stripe_transactions",
+            side_effect=counting_stripe,
+        ),
+    ):
+        for _ in range(20):
+            await cohort_analysis(months=6)
+
+    # 1 cold call + at most 0 warm calls (TTL holds for the duration of the test)
+    # Acceptance: <= 12 Stripe calls out of 20 requests (>= 40% reduction)
+    assert stripe_calls <= 12, (
+        f"Expected <= 12 Stripe calls; got {stripe_calls}. "
+        "Cache wiring may not be hitting. "
+        "Check REDIS_HOST/REDIS_PORT/REDIS_PASSWORD and that _fetch_stripe_transactions "
+        "is being called from compute_cohort_retention / compute_ltv_by_cohort / "
+        "compute_churn_by_cohort."
+    )

--- a/tests/integration/test_intelligence_contradictions.py
+++ b/tests/integration/test_intelligence_contradictions.py
@@ -1,0 +1,113 @@
+"""Integration test: cross-agent claims auto-populate contradicts.
+
+Requires a running local Supabase stack with SUPABASE_URL,
+SUPABASE_SERVICE_ROLE_KEY, SUPABASE_DB_URL set, AND a working embedding
+service (real Vertex AI / Google API key). When embeddings fall back to zeros
+(no credentials), cosine distance becomes NaN and no contradictions are flagged
+— the test is skipped in that case.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="env not set",
+    ),
+]
+
+
+def _embeddings_available() -> bool:
+    """Return True only when the embedding service will return real (non-zero) vectors."""
+    from app.rag.embedding_service import generate_embedding
+
+    emb = generate_embedding("test")
+    return any(v != 0.0 for v in emb[:10])
+
+
+@pytest.mark.asyncio
+async def test_conflicting_claims_auto_flag():
+    """Data's Q1 retention claim should flag Research's contradicting claim.
+
+    Writes a Research claim first (industry baseline 71%), then a Data claim
+    (company-specific 62%). Both are about the same entity and period, so
+    their embeddings should be close enough for detect_contradictions to flag
+    them. The Data claim's ``contradicts`` field should contain the Research
+    claim's UUID.
+
+    Skipped when the embedding service is in zero-vector fallback mode (no
+    Google credentials configured) — zero vectors produce NaN cosine distance
+    which cannot satisfy the similarity threshold.
+    """
+    loop = asyncio.get_event_loop()
+    real_embeddings = await loop.run_in_executor(None, _embeddings_available)
+    if not real_embeddings:
+        pytest.skip(
+            "Embedding service in zero-vector fallback mode (no Google credentials). "
+            "Contradiction detection requires real embeddings to compute cosine similarity. "
+            "Set GOOGLE_API_KEY or Vertex AI env vars and re-run."
+        )
+
+    from app.services.intelligence import (
+        find_claims,
+        get_or_create_entity,
+        write_claim,
+    )
+
+    e = await get_or_create_entity(
+        canonical_name=f"contradiction_q1_{uuid4()}",
+        entity_type="metric",
+        domains=["data", "research"],
+    )
+
+    # Research writes the industry baseline first
+    research_id = await write_claim(
+        entity_id=e,
+        domain="research",
+        finding_text=(
+            "Industry Q1 2026 customer retention averaged 71 percent across benchmarks"
+        ),
+        confidence=0.8,
+        sources=[{"kind": "url", "ref": "https://example.com/industry-report"}],
+        agent_id="research",
+        claim_type="research_finding",
+        embed=True,
+    )
+
+    # Data writes the company-specific claim — should auto-detect the research
+    # claim as a contradicting candidate
+    data_id = await write_claim(
+        entity_id=e,
+        domain="data",
+        finding_text=(
+            "Q1 2026 customer retention dropped to 62 percent at our company"
+        ),
+        confidence=0.85,
+        sources=[{"kind": "stripe_row", "ref": "test"}],
+        agent_id="data",
+        claim_type="cohort_summary",
+        embed=True,
+    )
+
+    # Inspect the data claim's contradicts field
+    all_claims = await find_claims(entity_id=e, limit=10)
+    target = next((c for c in all_claims if c.id == data_id), None)
+    assert target is not None, f"Data claim {data_id} not found in find_claims result"
+
+    # The research claim should be in contradicts
+    assert research_id in target.contradicts, (
+        f"Expected research claim {research_id} in contradicts, "
+        f"got {target.contradicts}. "
+        "Cosine similarity between the two claims may be below threshold. "
+        "Check actual distance and consider adjusting claim phrasings or threshold."
+    )

--- a/tests/integration/test_intelligence_contradictions.py
+++ b/tests/integration/test_intelligence_contradictions.py
@@ -19,8 +19,7 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.skipif(
         not all(
-            os.environ.get(var)
-            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+            os.environ.get(var) for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
         ),
         reason="env not set",
     ),

--- a/tests/integration/test_intelligence_search.py
+++ b/tests/integration/test_intelligence_search.py
@@ -1,0 +1,206 @@
+"""Integration tests for semantic search across agents (Plan 113-04).
+
+Requires local Supabase running with Phase 112 + 113-04 migrations applied.
+Requires SUPABASE_DB_URL for psycopg direct access.
+
+Skip with: pytest -m "not integration"
+
+Design note: _embed_text is patched to return deterministic vectors so the
+test does not depend on Vertex AI credentials. The two embeddings are
+purposefully distant in semantic space (cohort vector vs GDPR vector) to
+ensure cosine distance ordering is meaningful.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_DB_URL"]
+        ),
+        reason="SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, and SUPABASE_DB_URL must be set.",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Deterministic embeddings (768-dim, unit-normalised)
+# ---------------------------------------------------------------------------
+# COHORT_EMBED: first half 1s, second half 0s (normalised)
+# GDPR_EMBED:   first half 0s, second half 1s (normalised)
+# These are maximally distant in cosine space (distance ≈ 1.0 apart)
+# so "query_near_cohort" (≈ COHORT_EMBED) will be much closer to the cohort
+# claim than to the GDPR claim.
+
+import math
+
+_DIM = 768
+_HALF = _DIM // 2
+
+_COHORT_EMBED = [1.0 / math.sqrt(_HALF)] * _HALF + [0.0] * (_DIM - _HALF)
+_GDPR_EMBED = [0.0] * _HALF + [1.0 / math.sqrt(_DIM - _HALF)] * (_DIM - _HALF)
+# Query embedding — almost identical to cohort (slight noise in last position)
+_QUERY_EMBED = _COHORT_EMBED[:]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cleanup_entities():
+    """Track entity IDs created during the test and delete them after."""
+    created: list = []
+    yield created
+    if created:
+        try:
+            from supabase import create_client
+
+            url = os.environ.get("SUPABASE_URL")
+            key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
+            client = create_client(url, key)  # type: ignore[arg-type]
+            for entity_id in created:
+                try:
+                    client.table("kg_entities").delete().eq(
+                        "id", str(entity_id)
+                    ).execute()
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Main test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_returns_relevant_claims(cleanup_entities):
+    """Semantic search returns the cohort claim ranked above the GDPR claim.
+
+    Flow:
+    1. Seed two entities (cohort metric, GDPR regulation).
+    2. Write cohort claim with a "cohort-like" embedding.
+    3. Write GDPR claim with a "GDPR-like" embedding (orthogonal to cohort).
+    4. Search with a query near the cohort embedding.
+    5. Assert cohort claim appears before GDPR claim in results.
+    """
+    from app.services.intelligence.claims import (
+        get_or_create_entity,
+        search_claims_semantic,
+        write_claim,
+    )
+
+    # --- seed entities ---
+    cohort_entity_id = await get_or_create_entity(
+        canonical_name=f"cohort_search_test_{uuid4()}",
+        entity_type="metric",
+        domains=["data"],
+    )
+    cleanup_entities.append(cohort_entity_id)
+
+    gdpr_entity_id = await get_or_create_entity(
+        canonical_name=f"gdpr_search_test_{uuid4()}",
+        entity_type="regulation",
+        domains=["compliance"],
+    )
+    cleanup_entities.append(gdpr_entity_id)
+
+    # --- write cohort claim with cohort-like embedding ---
+    cohort_embed_mock = AsyncMock(return_value=_COHORT_EMBED)
+    with patch("app.services.intelligence.claims._embed_text", cohort_embed_mock):
+        await write_claim(
+            entity_id=cohort_entity_id,
+            domain="data",
+            finding_text=(
+                "SaaS cohort analysis: month-3 retention dropped 18% for Q1 2026 "
+                "cohort, indicating early churn pressure"
+            ),
+            confidence=0.88,
+            sources=[{"kind": "stripe_row", "ref": "cohort:2026-01"}],
+            agent_id="data",
+            claim_type="cohort_summary",
+            embed=True,
+        )
+
+    # --- write GDPR claim with GDPR-like embedding (orthogonal) ---
+    gdpr_embed_mock = AsyncMock(return_value=_GDPR_EMBED)
+    with patch("app.services.intelligence.claims._embed_text", gdpr_embed_mock):
+        await write_claim(
+            entity_id=gdpr_entity_id,
+            domain="compliance",
+            finding_text=(
+                "GDPR Article 17 right-to-erasure compliance review: data retention "
+                "policies require update for EU customer records"
+            ),
+            confidence=0.91,
+            sources=[{"kind": "regulation", "ref": "GDPR:Art17"}],
+            agent_id="compliance",
+            claim_type="compliance_finding",
+            embed=True,
+        )
+
+    # --- search with query near cohort ---
+    query_embed_mock = AsyncMock(return_value=_QUERY_EMBED)
+    with patch("app.services.intelligence.claims._embed_text", query_embed_mock):
+        results = await search_claims_semantic(
+            query="cohort retention drop", top_k=5
+        )
+
+    # --- assertions ---
+    assert len(results) >= 2, (
+        f"Expected at least 2 results; got {len(results)}. "
+        "Check that both claims have embeddings stored."
+    )
+
+    texts = [claim.finding_text for claim, _ in results]
+    sims = [sim for _, sim in results]
+
+    cohort_idx = next(
+        (i for i, (c, _) in enumerate(results) if c.agent_id == "data"), None
+    )
+    gdpr_idx = next(
+        (i for i, (c, _) in enumerate(results) if c.agent_id == "compliance"), None
+    )
+
+    assert cohort_idx is not None, f"Cohort claim not found in results: {texts}"
+    assert gdpr_idx is not None, f"GDPR claim not found in results: {texts}"
+
+    assert cohort_idx < gdpr_idx, (
+        f"Expected cohort claim (idx={cohort_idx}, sim={sims[cohort_idx]:.4f}) "
+        f"to rank above GDPR claim (idx={gdpr_idx}, sim={sims[gdpr_idx]:.4f}). "
+        "This may indicate the ivfflat index is not being used or the embeddings "
+        "were not stored."
+    )
+
+    # Results must be sorted ascending by distance
+    assert all(sims[i] <= sims[i + 1] for i in range(len(sims) - 1)), (
+        f"Results not sorted by ascending similarity distance: {sims}"
+    )
+
+    # Log EXPLAIN ANALYZE output for pgvector index verification (informational only)
+    try:
+        import psycopg
+        db_url = os.environ.get("SUPABASE_DB_URL")
+        if db_url:
+            with psycopg.connect(db_url) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "EXPLAIN ANALYZE SELECT id, (embedding <=> %s::vector) AS sim "
+                        "FROM kg_findings ORDER BY embedding <=> %s::vector ASC LIMIT 5",
+                        [_QUERY_EMBED, _QUERY_EMBED],
+                    )
+                    plan_rows = cur.fetchall()
+                    plan_text = "\n".join(r[0] for r in plan_rows)
+                    print(f"\n[EXPLAIN ANALYZE]\n{plan_text}\n")
+    except Exception as e:
+        print(f"[EXPLAIN ANALYZE skipped: {e}]")

--- a/tests/integration/test_intelligence_search.py
+++ b/tests/integration/test_intelligence_search.py
@@ -13,6 +13,7 @@ ensure cosine distance ordering is meaningful.
 
 from __future__ import annotations
 
+import math
 import os
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -38,8 +39,6 @@ pytestmark = [
 # These are maximally distant in cosine space (distance ≈ 1.0 apart)
 # so "query_near_cohort" (≈ COHORT_EMBED) will be much closer to the cohort
 # claim than to the GDPR claim.
-
-import math
 
 _DIM = 768
 _HALF = _DIM // 2
@@ -152,9 +151,7 @@ async def test_semantic_search_returns_relevant_claims(cleanup_entities):
     # --- search with query near cohort ---
     query_embed_mock = AsyncMock(return_value=_QUERY_EMBED)
     with patch("app.services.intelligence.claims._embed_text", query_embed_mock):
-        results = await search_claims_semantic(
-            query="cohort retention drop", top_k=5
-        )
+        results = await search_claims_semantic(query="cohort retention drop", top_k=5)
 
     # --- assertions ---
     assert len(results) >= 2, (
@@ -190,6 +187,7 @@ async def test_semantic_search_returns_relevant_claims(cleanup_entities):
     # Log EXPLAIN ANALYZE output for pgvector index verification (informational only)
     try:
         import psycopg
+
         db_url = os.environ.get("SUPABASE_DB_URL")
         if db_url:
             with psycopg.connect(db_url) as conn:

--- a/tests/integration/test_write_claim_with_contradictions_perf.py
+++ b/tests/integration/test_write_claim_with_contradictions_perf.py
@@ -21,8 +21,7 @@ pytestmark = [
     pytest.mark.slow,
     pytest.mark.skipif(
         not all(
-            os.environ.get(var)
-            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+            os.environ.get(var) for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
         ),
         reason="env not set",
     ),

--- a/tests/integration/test_write_claim_with_contradictions_perf.py
+++ b/tests/integration/test_write_claim_with_contradictions_perf.py
@@ -1,0 +1,119 @@
+"""Perf test: write_claim with embed=True + auto-contradiction stays under budget.
+
+20 measured writes after 5 warm-up writes; asserts p95 latency <= 750ms
+end-to-end (embedding + contradiction query + row insert).
+
+Requires a running local Supabase stack WITH real embedding credentials.
+In zero-vector fallback mode the test is skipped — executor overhead for
+the fallback path is not representative of production latency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not all(
+            os.environ.get(var)
+            for var in ["SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"]
+        ),
+        reason="env not set",
+    ),
+]
+
+
+def _embeddings_available() -> bool:
+    """Return True only when the embedding service returns real (non-zero) vectors."""
+    from app.rag.embedding_service import generate_embedding
+
+    emb = generate_embedding("test")
+    return any(v != 0.0 for v in emb[:10])
+
+
+@pytest.mark.asyncio
+async def test_write_claim_embed_true_p95_under_budget():
+    """20 writes of embed=True claims; p95 latency <= 750ms (rough end-to-end).
+
+    The 750ms budget encompasses:
+    - Embedding generation (~50-150ms with real Vertex AI / Google API creds)
+    - Contradiction detection pgvector query (~20-50ms on local Supabase)
+    - Supabase row insert (~50-100ms)
+    - JSON serialisation and network overhead
+
+    Skipped when embeddings are in zero-vector fallback mode; the fallback
+    path incurs abnormal executor cold-start overhead that is not representative
+    of production latency with real embedding calls.
+    """
+    loop = asyncio.get_event_loop()
+    real_embeddings = await loop.run_in_executor(None, _embeddings_available)
+    if not real_embeddings:
+        pytest.skip(
+            "Embedding service in zero-vector fallback mode (no Google credentials). "
+            "Performance test requires real embeddings to measure meaningful latency. "
+            "Set GOOGLE_API_KEY or Vertex AI env vars and re-run."
+        )
+
+    from uuid import uuid4
+
+    from app.services.intelligence import get_or_create_entity, write_claim
+
+    entity = await get_or_create_entity(
+        canonical_name=f"perf_test_{uuid4()}",
+        entity_type="topic",
+        domains=["test"],
+    )
+
+    # Seed 5 existing claims so contradiction-detect has rows to compare against
+    for i in range(5):
+        await write_claim(
+            entity_id=entity,
+            domain="test",
+            finding_text=(
+                f"Baseline observation {i}: stable behavior across cohorts "
+                "in the measurement window"
+            ),
+            confidence=0.5,
+            sources=[],
+            agent_id="test",
+            claim_type="probe",
+            embed=True,
+        )
+
+    latencies_ms: list[float] = []
+    for i in range(20):
+        start = time.perf_counter()
+        await write_claim(
+            entity_id=entity,
+            domain="test",
+            finding_text=(
+                f"New observation {i}: behavior changed in recent measurement window"
+            ),
+            confidence=0.6,
+            sources=[],
+            agent_id="test",
+            claim_type="probe",
+            embed=True,
+        )
+        latencies_ms.append((time.perf_counter() - start) * 1000)
+
+    latencies_ms.sort()
+    p50_idx = len(latencies_ms) // 2
+    p95_idx = int(len(latencies_ms) * 0.95)
+    p50 = latencies_ms[p50_idx]
+    p95 = latencies_ms[p95_idx]
+    print(f"\np50={p50:.1f}ms p95={p95:.1f}ms (n={len(latencies_ms)})")
+    print(f"min={latencies_ms[0]:.1f}ms max={latencies_ms[-1]:.1f}ms")
+
+    assert p95 <= 750, (
+        f"p95={p95:.0f}ms exceeds 750ms budget. "
+        "The contradiction detection query or embedding generation is too slow. "
+        "Consider reducing _contradiction_query_rows LIMIT from 20 to 10, "
+        "or adding a covering index on (entity_id, embedding IS NOT NULL)."
+    )

--- a/tests/unit/agents/data/test_cohort_analysis_confidence.py
+++ b/tests/unit/agents/data/test_cohort_analysis_confidence.py
@@ -66,7 +66,9 @@ _FAKE_COHORT_RESULT = {
         "total_customers": 42,
     },
     "ltv": {
-        "cohorts": {"2026-01": {"avg_ltv": 150.0, "total_revenue": 6300.0, "customer_count": 42}},
+        "cohorts": {
+            "2026-01": {"avg_ltv": 150.0, "total_revenue": 6300.0, "customer_count": 42}
+        },
         "overall_avg_ltv": 150.0,
     },
     "churn": {
@@ -97,7 +99,9 @@ def mock_cohort_service() -> MagicMock:
 
 
 @pytest.mark.asyncio
-async def test_cohort_analysis_confidence_field_present(mock_cohort_service: MagicMock) -> None:
+async def test_cohort_analysis_confidence_field_present(
+    mock_cohort_service: MagicMock,
+) -> None:
     """cohort_analysis result includes a float 'confidence' field."""
     _stub_modules()
     with (
@@ -122,7 +126,9 @@ async def test_cohort_analysis_confidence_field_present(mock_cohort_service: Mag
 
 
 @pytest.mark.asyncio
-async def test_cohort_analysis_band_field_present(mock_cohort_service: MagicMock) -> None:
+async def test_cohort_analysis_band_field_present(
+    mock_cohort_service: MagicMock,
+) -> None:
     """cohort_analysis result includes a 'band' literal string."""
     _stub_modules()
     with (

--- a/tests/unit/agents/data/test_cohort_analysis_confidence.py
+++ b/tests/unit/agents/data/test_cohort_analysis_confidence.py
@@ -1,0 +1,209 @@
+"""Unit tests for cohort_analysis tool — confidence / band fields (Phase 113-01).
+
+Verifies that after wiring data_confidence into the cohort_analysis tool
+(app/agents/data/tools.py) the returned dict contains:
+  - "confidence": a float in [0.0, 1.0]
+  - "band": one of "low" | "medium" | "high"
+
+Uses the sys.modules stub pattern from Phase 49-05 to avoid the
+slowapi/starlette .env UnicodeDecodeError on Windows before importing.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs to sidestep expensive / env-dependent imports
+# ---------------------------------------------------------------------------
+
+_FAKE_ENV = {
+    "SUPABASE_URL": "https://example.supabase.co",
+    "SUPABASE_SERVICE_ROLE_KEY": "service-role-test-key",
+    "SUPABASE_ANON_KEY": "anon-test-key",
+    "GOOGLE_API_KEY": "fake-api-key",
+}
+
+
+def _stub_modules() -> None:
+    """Inject minimal stubs so tools.py can be imported without side-effects.
+
+    Note: starlette is a real installed package so we must NOT stub it.
+    Only stub slowapi (which tries to import starlette internals at import-time
+    in some configurations) and google.adk / google.genai (heavyweight SDKs).
+    """
+    for mod_name in [
+        "slowapi",
+        "slowapi.util",
+        "slowapi.errors",
+        "slowapi.middleware",
+    ]:
+        if mod_name not in sys.modules:
+            sys.modules[mod_name] = types.ModuleType(mod_name)
+
+    # google is a namespace package; only stub the sub-packages if absent
+    for mod_name in ["google.adk", "google.genai"]:
+        if mod_name not in sys.modules:
+            parent, _, child = mod_name.rpartition(".")
+            stub = types.ModuleType(mod_name)
+            sys.modules[mod_name] = stub
+            if parent in sys.modules:
+                setattr(sys.modules[parent], child, stub)
+
+
+# ---------------------------------------------------------------------------
+# Fake cohort result returned by CohortAnalysisService.full_cohort_analysis
+# ---------------------------------------------------------------------------
+
+_FAKE_COHORT_RESULT = {
+    "retention": {
+        "cohorts": {"2026-01": {"month_0": 100.0, "month_1": 75.0}},
+        "months_analyzed": 6,
+        "total_customers": 42,
+    },
+    "ltv": {
+        "cohorts": {"2026-01": {"avg_ltv": 150.0, "total_revenue": 6300.0, "customer_count": 42}},
+        "overall_avg_ltv": 150.0,
+    },
+    "churn": {
+        "cohorts": {"2026-01": {"churn_rate": 0.05, "churned": 2, "total": 42}},
+        "overall_churn_rate": 0.05,
+    },
+    "executive_summary": "42 customers, good retention.",
+    "chart_data": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_cohort_service() -> MagicMock:
+    """Return a MagicMock CohortAnalysisService with full_cohort_analysis stubbed."""
+    svc = MagicMock()
+    svc.full_cohort_analysis = AsyncMock(return_value=_FAKE_COHORT_RESULT)
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_confidence_field_present(mock_cohort_service: MagicMock) -> None:
+    """cohort_analysis result includes a float 'confidence' field."""
+    _stub_modules()
+    with (
+        patch.dict("os.environ", _FAKE_ENV, clear=False),
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=mock_cohort_service,
+        ),
+        patch(
+            "app.services.request_context.get_current_user_id",
+            return_value="test-user",
+        ),
+    ):
+        from app.agents.data.tools import cohort_analysis
+
+        result = await cohort_analysis(months=6)
+
+    assert result["success"] is True
+    assert "confidence" in result, "expected 'confidence' key in result"
+    assert isinstance(result["confidence"], float), "confidence must be a float"
+    assert 0.0 <= result["confidence"] <= 1.0, "confidence must be in [0.0, 1.0]"
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_band_field_present(mock_cohort_service: MagicMock) -> None:
+    """cohort_analysis result includes a 'band' literal string."""
+    _stub_modules()
+    with (
+        patch.dict("os.environ", _FAKE_ENV, clear=False),
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=mock_cohort_service,
+        ),
+        patch(
+            "app.services.request_context.get_current_user_id",
+            return_value="test-user",
+        ),
+    ):
+        from app.agents.data.tools import cohort_analysis
+
+        result = await cohort_analysis(months=6)
+
+    assert "band" in result, "expected 'band' key in result"
+    assert result["band"] in {"low", "medium", "high"}, (
+        f"band must be low/medium/high, got {result['band']!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_confidence_high_for_good_data(
+    mock_cohort_service: MagicMock,
+) -> None:
+    """42 customers, 0 missing, 0 sigma, 1h age → confidence in 'high' band (>= 0.75)."""
+    _stub_modules()
+    with (
+        patch.dict("os.environ", _FAKE_ENV, clear=False),
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=mock_cohort_service,
+        ),
+        patch(
+            "app.services.request_context.get_current_user_id",
+            return_value="test-user",
+        ),
+    ):
+        from app.agents.data.tools import cohort_analysis
+
+        result = await cohort_analysis(months=6)
+
+    # With defaults: missing=0, sigma=0, age=1h and 42 customers (< 100 threshold)
+    # sample_adequacy = 0.42, completeness=1.0, strength=1.0, recency≈0.9986
+    # score ≈ 0.42*0.35 + 1.0*0.25 + 1.0*0.25 + 0.9986*0.15 ≈ 0.797 → "high"
+    assert result["band"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_cohort_analysis_no_customers_no_confidence_key() -> None:
+    """When total_customers == 0 the early-return path omits confidence/band fields."""
+    _stub_modules()
+    empty_result = {
+        "retention": {"cohorts": {}, "months_analyzed": 6, "total_customers": 0},
+        "ltv": {},
+        "churn": {},
+        "executive_summary": "",
+        "chart_data": {},
+    }
+    svc = MagicMock()
+    svc.full_cohort_analysis = AsyncMock(return_value=empty_result)
+
+    with (
+        patch.dict("os.environ", _FAKE_ENV, clear=False),
+        patch(
+            "app.services.cohort_analysis_service.CohortAnalysisService",
+            return_value=svc,
+        ),
+        patch(
+            "app.services.request_context.get_current_user_id",
+            return_value="test-user",
+        ),
+    ):
+        from app.agents.data.tools import cohort_analysis
+
+        result = await cohort_analysis(months=6)
+
+    assert result["success"] is True
+    assert "message" in result  # early-return message path
+    # confidence/band not present on the empty-data early-exit path
+    assert "confidence" not in result
+    assert "band" not in result

--- a/tests/unit/services/intelligence/test_contradictions.py
+++ b/tests/unit/services/intelligence/test_contradictions.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 
@@ -21,17 +21,22 @@ async def test_detect_contradictions_returns_high_similarity_uuids():
         {"id": str(dissimilar_id), "similarity": 0.50},  # far
     ]
 
-    with patch(
-        "app.services.intelligence.claims._embed_text",
-        new=AsyncMock(return_value=[0.1] * 768),
-    ), patch(
-        "app.services.intelligence.claims._contradiction_query_rows",
-        new=AsyncMock(return_value=fake_rows),
+    with (
+        patch(
+            "app.services.intelligence.claims._embed_text",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ),
+        patch(
+            "app.services.intelligence.claims._contradiction_query_rows",
+            new=AsyncMock(return_value=fake_rows),
+        ),
     ):
         # threshold 0.85 means: similarity (= 1 - distance) >= 0.85,
         # so distance <= 0.15. Only similar_id qualifies (distance=0.05).
         result = await detect_contradictions(
-            "Q1 2026 retention dropped to 62 percent", entity_id=entity, threshold=0.85,
+            "Q1 2026 retention dropped to 62 percent",
+            entity_id=entity,
+            threshold=0.85,
         )
 
     assert similar_id in result
@@ -48,7 +53,8 @@ async def test_detect_contradictions_no_embedding_returns_empty():
         new=AsyncMock(return_value=None),
     ):
         result = await detect_contradictions(
-            "anything longer than twenty chars", entity_id=uuid4(),
+            "anything longer than twenty chars",
+            entity_id=uuid4(),
         )
     assert result == []
 
@@ -65,15 +71,19 @@ async def test_detect_contradictions_filters_by_entity():
         return []
 
     entity = uuid4()
-    with patch(
-        "app.services.intelligence.claims._embed_text",
-        new=AsyncMock(return_value=[0.1] * 768),
-    ), patch(
-        "app.services.intelligence.claims._contradiction_query_rows",
-        side_effect=capture_query,
+    with (
+        patch(
+            "app.services.intelligence.claims._embed_text",
+            new=AsyncMock(return_value=[0.1] * 768),
+        ),
+        patch(
+            "app.services.intelligence.claims._contradiction_query_rows",
+            side_effect=capture_query,
+        ),
     ):
         await detect_contradictions(
-            "this text is longer than twenty chars", entity_id=entity,
+            "this text is longer than twenty chars",
+            entity_id=entity,
         )
 
     assert captured["entity_id"] == entity

--- a/tests/unit/services/intelligence/test_contradictions.py
+++ b/tests/unit/services/intelligence/test_contradictions.py
@@ -1,0 +1,79 @@
+"""Unit tests for detect_contradictions with mocked embedding + DB."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_returns_high_similarity_uuids():
+    """Rows above threshold are returned as contradicting candidates."""
+    from app.services.intelligence.claims import detect_contradictions
+
+    entity = uuid4()
+    similar_id = uuid4()
+    dissimilar_id = uuid4()
+    fake_rows = [
+        {"id": str(similar_id), "similarity": 0.05},  # very close (0.05 distance)
+        {"id": str(dissimilar_id), "similarity": 0.50},  # far
+    ]
+
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=[0.1] * 768),
+    ), patch(
+        "app.services.intelligence.claims._contradiction_query_rows",
+        new=AsyncMock(return_value=fake_rows),
+    ):
+        # threshold 0.85 means: similarity (= 1 - distance) >= 0.85,
+        # so distance <= 0.15. Only similar_id qualifies (distance=0.05).
+        result = await detect_contradictions(
+            "Q1 2026 retention dropped to 62 percent", entity_id=entity, threshold=0.85,
+        )
+
+    assert similar_id in result
+    assert dissimilar_id not in result
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_no_embedding_returns_empty():
+    """If embedding generation fails, return [] (degrade silently)."""
+    from app.services.intelligence.claims import detect_contradictions
+
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await detect_contradictions(
+            "anything longer than twenty chars", entity_id=uuid4(),
+        )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_detect_contradictions_filters_by_entity():
+    """Only rows attached to the entity are considered."""
+    from app.services.intelligence.claims import detect_contradictions
+
+    captured = {}
+
+    async def capture_query(*, embedding, entity_id):
+        captured["entity_id"] = entity_id
+        return []
+
+    entity = uuid4()
+    with patch(
+        "app.services.intelligence.claims._embed_text",
+        new=AsyncMock(return_value=[0.1] * 768),
+    ), patch(
+        "app.services.intelligence.claims._contradiction_query_rows",
+        side_effect=capture_query,
+    ):
+        await detect_contradictions(
+            "this text is longer than twenty chars", entity_id=entity,
+        )
+
+    assert captured["entity_id"] == entity

--- a/tests/unit/services/intelligence/test_presets_data.py
+++ b/tests/unit/services/intelligence/test_presets_data.py
@@ -13,10 +13,7 @@ from __future__ import annotations
 
 import math
 
-import pytest
-
 from app.services.intelligence.presets.data import DATA_WEIGHTS, data_confidence
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -106,7 +103,7 @@ def test_sigma_zero_gives_full_statistical_strength():
 
 
 def test_sigma_at_three_gives_zero_statistical_strength():
-    """sigma_distance=3.0 → statistical_strength=0.0 (saturates at 3σ)."""
+    """sigma_distance=3.0 -> statistical_strength=0.0 (saturates at 3 sigma)."""
     result = data_confidence(100, 0.0, 3.0, 1.0)
     expected = _expected(100, 0.0, 3.0, 1.0)
     assert math.isclose(result, expected, abs_tol=1e-9)

--- a/tests/unit/services/intelligence/test_presets_data.py
+++ b/tests/unit/services/intelligence/test_presets_data.py
@@ -1,0 +1,181 @@
+"""Unit tests for app.services.intelligence.presets.data.data_confidence.
+
+15 boundary tests covering:
+- Zero / tiny / full / oversized-clamped sample_size
+- missing_pct variants (0, 0.5, 1.0)
+- sigma_distance at 0, 1.5, 3.0, > 3 (saturation / clamping)
+- recency horizon boundary (exactly at horizon, past horizon)
+- Custom sample_threshold and recency_horizon_hours
+- All-best (expected near 1.0) and all-worst (expected near 0.0) inputs
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from app.services.intelligence.presets.data import DATA_WEIGHTS, data_confidence
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _expected(
+    sample_size: int,
+    missing_pct: float,
+    sigma_distance: float,
+    data_age_hours: float,
+    *,
+    sample_threshold: int = 100,
+    recency_horizon_hours: float = 720,
+) -> float:
+    """Reference implementation that mirrors the plan formula exactly."""
+    w = DATA_WEIGHTS
+    sample_adequacy = min(1.0, sample_size / sample_threshold)
+    completeness = max(0.0, 1.0 - missing_pct)
+    statistical_strength = max(0.0, 1.0 - min(1.0, sigma_distance / 3.0))
+    recency = max(0.0, 1.0 - min(1.0, data_age_hours / recency_horizon_hours))
+    raw = (
+        sample_adequacy * w["sample_adequacy"]
+        + completeness * w["completeness"]
+        + statistical_strength * w["statistical_strength"]
+        + recency * w["recency"]
+    )
+    return max(0.0, min(1.0, raw))
+
+
+# ---------------------------------------------------------------------------
+# Boundary tests
+# ---------------------------------------------------------------------------
+
+
+def test_zero_sample_size():
+    """sample_size=0 drives sample_adequacy to 0 — score is still positive via other signals."""
+    result = data_confidence(0, 0.0, 0.0, 1.0)
+    expected = _expected(0, 0.0, 0.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+    assert result >= 0.0
+
+
+def test_sample_size_exactly_at_threshold():
+    """sample_size == sample_threshold gives sample_adequacy == 1.0."""
+    result = data_confidence(100, 0.0, 0.0, 1.0)
+    expected = _expected(100, 0.0, 0.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+
+
+def test_sample_size_oversized_clamped():
+    """sample_size >> sample_threshold is clamped to 1.0, not > 1.0."""
+    result = data_confidence(9999, 0.0, 0.0, 1.0)
+    expected = _expected(9999, 0.0, 0.0, 1.0)
+    # Both should give same result as sample_size=100
+    result_at_threshold = data_confidence(100, 0.0, 0.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+    assert math.isclose(result, result_at_threshold, abs_tol=1e-9)
+
+
+def test_missing_pct_zero():
+    """missing_pct=0 → completeness=1.0 (all data present)."""
+    result = data_confidence(100, 0.0, 0.0, 1.0)
+    expected = _expected(100, 0.0, 0.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+
+
+def test_missing_pct_half():
+    """missing_pct=0.5 → completeness=0.5."""
+    result = data_confidence(100, 0.5, 0.0, 1.0)
+    expected = _expected(100, 0.5, 0.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+
+
+def test_missing_pct_full():
+    """missing_pct=1.0 → completeness=0.0 (all fields missing)."""
+    result = data_confidence(100, 1.0, 0.0, 1.0)
+    expected = _expected(100, 1.0, 0.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+
+
+def test_sigma_zero_gives_full_statistical_strength():
+    """sigma_distance=0 → statistical_strength=1.0 (no deviation from baseline)."""
+    result = data_confidence(100, 0.0, 0.0, 1.0)
+    expected = _expected(100, 0.0, 0.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+
+
+def test_sigma_at_three_gives_zero_statistical_strength():
+    """sigma_distance=3.0 → statistical_strength=0.0 (saturates at 3σ)."""
+    result = data_confidence(100, 0.0, 3.0, 1.0)
+    expected = _expected(100, 0.0, 3.0, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+    # Without the statistical_strength signal, score should be < all-zeros-sigma score
+    result_sigma_zero = data_confidence(100, 0.0, 0.0, 1.0)
+    assert result < result_sigma_zero
+
+
+def test_sigma_greater_than_three_clamped():
+    """sigma_distance > 3 is clamped — same as sigma=3 (no negative contribution)."""
+    result_3 = data_confidence(100, 0.0, 3.0, 1.0)
+    result_10 = data_confidence(100, 0.0, 10.0, 1.0)
+    assert math.isclose(result_3, result_10, abs_tol=1e-9)
+
+
+def test_sigma_at_one_point_five():
+    """sigma_distance=1.5 → statistical_strength=0.5 (halfway)."""
+    result = data_confidence(100, 0.0, 1.5, 1.0)
+    expected = _expected(100, 0.0, 1.5, 1.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+
+
+def test_data_age_at_recency_horizon():
+    """data_age_hours == recency_horizon_hours → recency=0.0."""
+    result = data_confidence(100, 0.0, 0.0, 720.0)
+    expected = _expected(100, 0.0, 0.0, 720.0)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+    # recency=0 means the 0.15 weight is zeroed out
+    result_fresh = data_confidence(100, 0.0, 0.0, 1.0)
+    assert result < result_fresh
+
+
+def test_data_age_past_recency_horizon_clamped():
+    """data_age_hours >> horizon is clamped to recency=0.0 (no negative)."""
+    result_at = data_confidence(100, 0.0, 0.0, 720.0)
+    result_past = data_confidence(100, 0.0, 0.0, 9999.0)
+    assert math.isclose(result_at, result_past, abs_tol=1e-9)
+
+
+def test_custom_sample_threshold():
+    """Custom sample_threshold=50 means sample_size=50 is fully adequate."""
+    result_custom = data_confidence(50, 0.0, 0.0, 1.0, sample_threshold=50)
+    result_default = data_confidence(100, 0.0, 0.0, 1.0, sample_threshold=100)
+    assert math.isclose(result_custom, result_default, abs_tol=1e-9)
+
+
+def test_custom_recency_horizon():
+    """Custom recency_horizon_hours=48 ages out at 2 days."""
+    result = data_confidence(100, 0.0, 0.0, 48.0, recency_horizon_hours=48)
+    expected = _expected(100, 0.0, 0.0, 48.0, recency_horizon_hours=48)
+    assert math.isclose(result, expected, abs_tol=1e-9)
+    # recency=0 at exactly the horizon
+    result_fresh = data_confidence(100, 0.0, 0.0, 1.0, recency_horizon_hours=48)
+    assert result < result_fresh
+
+
+def test_all_best_inputs_returns_one():
+    """All signals at best possible values → confidence == 1.0.
+
+    sample_size >> threshold, missing=0, sigma=0, age=0h.
+    """
+    result = data_confidence(10000, 0.0, 0.0, 0.0)
+    assert math.isclose(result, 1.0, abs_tol=1e-9)
+
+
+def test_all_worst_inputs_returns_zero():
+    """All signals at worst possible values → confidence == 0.0.
+
+    sample_size=0, missing=1.0, sigma>=3, age>=horizon.
+    """
+    result = data_confidence(0, 1.0, 3.0, 720.0)
+    assert math.isclose(result, 0.0, abs_tol=1e-9)

--- a/tests/unit/services/intelligence/test_search.py
+++ b/tests/unit/services/intelligence/test_search.py
@@ -6,15 +6,15 @@ These tests mock all I/O — no real DB or Vertex AI calls are made.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helper: build a minimal raw DB row (as psycopg would return)
 # ---------------------------------------------------------------------------
+
 
 def _make_row(
     *,

--- a/tests/unit/services/intelligence/test_search.py
+++ b/tests/unit/services/intelligence/test_search.py
@@ -1,0 +1,157 @@
+"""Unit tests for app.services.intelligence.claims.search_claims_semantic (Plan 113-04).
+
+These tests mock all I/O — no real DB or Vertex AI calls are made.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal raw DB row (as psycopg would return)
+# ---------------------------------------------------------------------------
+
+def _make_row(
+    *,
+    finding_text: str = "test finding",
+    confidence: float = 0.85,
+    agent_id: str = "data",
+    claim_type: str = "cohort_summary",
+    domain: str = "data",
+    similarity: float = 0.12,
+) -> dict:
+    """Build a dict mimicking what _semantic_query_rows returns."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    return {
+        "id": str(uuid4()),
+        "entity_id": str(uuid4()),
+        "edge_id": None,
+        "agent_id": agent_id,
+        "claim_type": claim_type,
+        "domain": domain,
+        "finding_text": finding_text,
+        "confidence": confidence,
+        "sources": [],
+        "contradicts": [],
+        "freshness_at": now_iso,
+        "expires_at": None,
+        "created_at": now_iso,
+        "similarity": similarity,
+    }
+
+
+# ---------------------------------------------------------------------------
+# test_search_claims_semantic_returns_claims_ordered_by_similarity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_claims_semantic_returns_claims_ordered_by_similarity():
+    """Mocked DB rows come back as Claim objects, distances preserved as similarity floats."""
+    from app.services.intelligence.claims import search_claims_semantic
+    from app.services.intelligence.schemas import Claim
+
+    row_near = _make_row(
+        finding_text="cohort retention dropped 12% in Q1",
+        similarity=0.05,  # closer (lower cosine distance)
+    )
+    row_far = _make_row(
+        finding_text="GDPR compliance regulation review",
+        claim_type="compliance_finding",
+        agent_id="compliance",
+        similarity=0.80,
+    )
+
+    mock_embed = AsyncMock(return_value=[0.1] * 768)
+    mock_query = AsyncMock(return_value=[row_near, row_far])
+
+    with (
+        patch(
+            "app.services.intelligence.claims._embed_text",
+            mock_embed,
+        ),
+        patch(
+            "app.services.intelligence.claims._semantic_query_rows",
+            mock_query,
+        ),
+    ):
+        results = await search_claims_semantic(query="cohort retention drop", top_k=10)
+
+    assert len(results) == 2
+    # Each element is (Claim, float)
+    claim0, sim0 = results[0]
+    claim1, sim1 = results[1]
+    assert isinstance(claim0, Claim)
+    assert isinstance(claim1, Claim)
+    assert sim0 == pytest.approx(0.05)
+    assert sim1 == pytest.approx(0.80)
+    assert claim0.finding_text == "cohort retention dropped 12% in Q1"
+    assert claim1.finding_text == "GDPR compliance regulation review"
+
+
+# ---------------------------------------------------------------------------
+# test_search_claims_semantic_skips_when_embedding_fails
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_claims_semantic_skips_when_embedding_fails():
+    """If embedding generation returns None, function returns empty list immediately."""
+    from app.services.intelligence.claims import search_claims_semantic
+
+    mock_embed = AsyncMock(return_value=None)
+    mock_query = AsyncMock()  # should NOT be called
+
+    with (
+        patch(
+            "app.services.intelligence.claims._embed_text",
+            mock_embed,
+        ),
+        patch(
+            "app.services.intelligence.claims._semantic_query_rows",
+            mock_query,
+        ),
+    ):
+        results = await search_claims_semantic(query="any query", top_k=5)
+
+    assert results == []
+    mock_query.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# test_search_claims_semantic_top_k_respected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_claims_semantic_top_k_respected():
+    """top_k argument is forwarded to _semantic_query_rows."""
+    from app.services.intelligence.claims import search_claims_semantic
+
+    mock_embed = AsyncMock(return_value=[0.0] * 768)
+    mock_query = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "app.services.intelligence.claims._embed_text",
+            mock_embed,
+        ),
+        patch(
+            "app.services.intelligence.claims._semantic_query_rows",
+            mock_query,
+        ),
+    ):
+        await search_claims_semantic(query="test", top_k=3)
+
+    mock_query.assert_called_once()
+    call_kwargs = mock_query.call_args
+    # _semantic_query_rows is called with keyword args
+    assert call_kwargs.kwargs.get("top_k") == 3 or (
+        # fallback: positional call — check keyword or args
+        len(call_kwargs.args) == 0 and call_kwargs.kwargs.get("top_k") == 3
+    )


### PR DESCRIPTION
## Summary

Phase 113 is the first non-research adoption of the shared intelligence infrastructure shipped in Phase 112 (PR #40). Data Agent's `cohort_analysis` gains a calibrated confidence band, two-tier adaptive cache (graph + Redis), emits structured claims into `kg_findings`, and becomes searchable across all agents via the new Executive `search_agent_claims` ADK tool.

**Stacked on PR #40** — this PR's base is `ship/phase-112-shared-intelligence`. Once #40 merges, GitHub will retarget this PR's base to `main` automatically.

## What's in this PR

5 sub-plans, 31 commits, 5 design plans + ~3,028 lines of TDD task breakdowns + the implementation:

- **Plan 113-01** — `data_confidence(sample_size, missing_pct, sigma_distance, data_age_hours)` preset + pilot wiring into `cohort_analysis`. Response payload now carries `confidence` + `band` fields.
- **Plan 113-02** — Two-tier cache around `cohort_analysis`: graph-tier short-circuit when a fresh `cohort_summary` claim exists, Redis-tier 5-min caching around the Stripe call.
- **Plan 113-03** — Emit `cohort_summary` + per-month `cohort_retention_mN` claims. Documents the claim-type vocabulary at `docs/intelligence/claim-types.md`. The two-tier cache from 113-02 now actually hits because claims are being written.
- **Plan 113-04** — `search_claims_semantic` with pgvector cosine-distance ORDER BY. ivfflat index migration. Embeddings on `cohort_summary` writes. **First justified ADK tool in the intelligence package**: `search_agent_claims` registered with ExecutiveAgent (reasoning-driven retrieval where LLM tool calls add value).
- **Plan 113-05** — `detect_contradictions(text, entity_id, threshold=0.85)` + auto-populate `kg_findings.contradicts` on `write_claim` when `embed=True`. 50-pair hand-curated tuning fixture.

## Test plan

- [ ] PR #40 (Phase 112) merged first — without it, the schema migration + intelligence package don't exist
- [ ] Local Supabase running with Phase 112 + the new ivfflat migration applied via docker exec
- [ ] Local Redis running with password `pikar_dev_redis`
- [ ] Env vars set: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`, `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`
- [ ] **Plus `GOOGLE_API_KEY` or Vertex AI credentials** to exercise the 3 contradiction-detection integration tests (they `pytest.skip` cleanly without)
- [ ] Run: `uv run pytest tests/unit/services/intelligence/ tests/unit/agents/data/ tests/integration/test_data_cache_integration.py tests/integration/test_intelligence_search.py tests/integration/test_intelligence_contradictions.py`
- [ ] Expect ~50 tests pass; 3 contradiction integration tests skip without Google API creds (intentional skip guard)

## Key design choices

- **`statistical_strength = 1 - sigma/3`** inverts the sigma signal — high sigma means anomalous, which means LOWER confidence in trend stability (not higher). Deliberate, with a unit test pinning the behavior.
- **Two-tier cache split:** graph for semantic claims (24h TTL), Redis for raw Stripe responses (5min TTL). Asymmetric TTLs match reality — claims have epistemic value that ages slowly; raw Stripe data ages fast.
- **Secondary-write exception:** `cohort_analysis` wraps claim emission in `try/except` because graph persistence is a side-effect, not the user's primary deliverable. Documented inline. This is the ONLY place in the intelligence layer that deviates from "writes fail loudly" — and the deviation is bounded to a specific tool that has primary work to deliver.
- **`embed=True` only for `cohort_summary`**, not per-month retention claims — embeddings are costly and the short numerical month-N strings have low semantic-search value.
- **Contradiction detection is a SIGNAL**, not interpretation — 0.85 similarity flags "may contradict, worth human review." LLM-in-the-loop verification is deferred.
- **ivfflat over hnsw** for `kg_findings.embedding` — conservative for ≤500k rows. Migrate to hnsw if/when row count exceeds 1M.

## Known limitations

- **Plan 113-02 test mocking is too coarse** — load test mocks `full_cohort_analysis`, so the compute methods that actually call `_fetch_stripe_transactions` don't run during the test. Wiring is structurally correct (verified by reading); a follow-up test mocking only `_fetch_stripe_revenue` at the lowest level would close the loop.
- **Plan 113-05's 3 integration tests skip without Google API creds** — `_embed_text` falls back to zero vectors locally, which break pgvector cosine-distance. The skip guard is intentional. The threshold of 0.85 is provisional until exercised against the 50-pair fixture with real embeddings.
- **ivfflat index not yet picked at local dev scale** — with ~24 rows the planner uses Seq Scan. The index is created and verified; it'll select once row count grows.

## Out of scope for this PR

- Other 8 specialized agents adopting (separate phases per the spec)
- Replacing `app/agents/tools/deep_research.py` (different concept)
- Per-agent budget tracking
- LLM-in-the-loop contradiction interpretation

🤖 Generated with [Claude Code](https://claude.com/claude-code)