### PR TITLE
fix(dashboard): restore department_health_summary view + fix workspace SSE auth

### DIFF
--- a/frontend/src/app/api/workspace/events/route.test.ts
+++ b/frontend/src/app/api/workspace/events/route.test.ts
@@ -6,6 +6,19 @@
 // Proprietary and confidential. See LICENSE file for details.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hoisted so the mocked module is in place before `./route` is evaluated.
+const getSessionMock = vi.hoisted(() => vi.fn());
+const createClientMock = vi.hoisted(() =>
+    vi.fn(async () => ({
+        auth: { getSession: getSessionMock },
+    })),
+);
+
+vi.mock('@/lib/supabase/server', () => ({
+    createClient: createClientMock,
+}));
+
 import { GET } from './route';
 
 describe('GET /api/workspace/events', () => {
@@ -13,6 +26,7 @@ describe('GET /api/workspace/events', () => {
         process.env.NEXT_PUBLIC_API_URL = 'https://api.example.com';
         delete process.env.WORKSPACE_EVENTS_BACKEND_URL;
         vi.restoreAllMocks();
+        getSessionMock.mockResolvedValue({ data: { session: null }, error: null });
     });
 
     afterEach(() => {
@@ -61,6 +75,48 @@ describe('GET /api/workspace/events', () => {
         expect(headers.cookie).toBe('sb-session=abc');
         expect(headers.authorization).toBe('Bearer token-123');
         expect(headers.accept).toBe('text/event-stream');
+    });
+
+    it('injects the Supabase access token as Bearer when no Authorization header is supplied', async () => {
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: 'cookie-derived-jwt' } },
+            error: null,
+        });
+        const upstream = new Response(new ReadableStream(), {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+        });
+        const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(upstream);
+
+        const req = new Request('http://localhost/api/workspace/events', {
+            headers: { cookie: 'sb-access-token=abc' },
+        });
+        await GET(req as unknown as Request);
+
+        const init = fetchSpy.mock.calls[0][1] as RequestInit;
+        const headers = init.headers as Record<string, string>;
+        expect(headers.authorization).toBe('Bearer cookie-derived-jwt');
+    });
+
+    it('prefers an explicit Authorization header over the cookie-derived token', async () => {
+        getSessionMock.mockResolvedValue({
+            data: { session: { access_token: 'cookie-derived-jwt' } },
+            error: null,
+        });
+        const upstream = new Response(new ReadableStream(), {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+        });
+        const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(upstream);
+
+        const req = new Request('http://localhost/api/workspace/events', {
+            headers: { authorization: 'Bearer explicit-jwt' },
+        });
+        await GET(req as unknown as Request);
+
+        const init = fetchSpy.mock.calls[0][1] as RequestInit;
+        const headers = init.headers as Record<string, string>;
+        expect(headers.authorization).toBe('Bearer explicit-jwt');
     });
 
     it('uses WORKSPACE_EVENTS_BACKEND_URL when set, overriding NEXT_PUBLIC_API_URL', async () => {

--- a/frontend/src/app/api/workspace/events/route.ts
+++ b/frontend/src/app/api/workspace/events/route.ts
@@ -5,13 +5,15 @@
  * Proxy for the per-user workspace SSE channel.
  *
  * The browser hook (`useWorkspaceEvents`) opens an `EventSource` against the
- * Next.js origin so cookie auth flows naturally. The FastAPI backend exposes
- * the actual stream at `${BACKEND}/workspace/events`. This route forwards the
- * request — auth cookie + `Authorization` header included — and pipes the
- * upstream `ReadableStream` straight back to the client without buffering.
+ * Next.js origin. Native `EventSource` cannot attach an `Authorization`
+ * header, and the FastAPI backend at `${BACKEND}/workspace/events` requires
+ * `Authorization: Bearer <jwt>`. So we use the SSR Supabase client to read
+ * the access token from the auth cookie and inject it as a Bearer header
+ * before piping the upstream `ReadableStream` straight back to the client.
  */
 
 import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -29,13 +31,33 @@ function resolveBackendUrl(): string {
 export async function GET(req: Request): Promise<Response> {
     const upstreamUrl = `${resolveBackendUrl().replace(/\/$/, '')}/workspace/events`;
 
+    // Pull the Supabase access token from the auth cookie. EventSource can
+    // only send cookies, so the backend's Bearer-only auth would otherwise
+    // reject the request with 403. (See sessions/list/route.ts for the
+    // same SSR cookie → Bearer pattern.)
+    let accessToken: string | null = null;
+    try {
+        const supabase = await createClient();
+        const { data: sessionData } = await supabase.auth.getSession();
+        accessToken = sessionData.session?.access_token ?? null;
+    } catch (err) {
+        // Cookie store or Supabase client failure — fall through to upstream
+        // attempt below; the existing Authorization header (if any) still
+        // gets a chance to authenticate.
+        console.error('[api/workspace/events] supabase session read failed:', err);
+    }
+
     const headers: Record<string, string> = {
         accept: 'text/event-stream',
     };
     const cookie = req.headers.get('cookie');
     if (cookie) headers.cookie = cookie;
     const auth = req.headers.get('authorization');
-    if (auth) headers.authorization = auth;
+    if (auth) {
+        headers.authorization = auth;
+    } else if (accessToken) {
+        headers.authorization = `Bearer ${accessToken}`;
+    }
 
     try {
         const upstream = await fetch(upstreamUrl, {

--- a/supabase/migrations/20260519160000_restore_department_health_summary_view.sql
+++ b/supabase/migrations/20260519160000_restore_department_health_summary_view.sql
@@ -1,0 +1,73 @@
+-- Copyright (c) 2024-2026 Pikar AI. All rights reserved.
+-- Migration: restore department_health_summary view
+--
+-- Background:
+--   20260403400000_department_tasks.sql originally created the
+--   ``department_health_summary`` view. That migration was recorded as
+--   applied in ``supabase_migrations.schema_migrations`` but the objects
+--   never materialised on remote (per the 2026-04-27 b484 →
+--   pikar-ai-project Cloud Run move — see project_cloud_run_migration.md).
+--
+--   20260511120050_restore_department_tasks.sql brought back the
+--   ``department_tasks`` table, indexes, and RLS policies but explicitly
+--   deferred the view, citing an assumed dependency on
+--   ``_governance_set_updated_at``. The view does NOT depend on that
+--   function — only the (also-deferred) ``dept_tasks_set_updated_at``
+--   trigger does. Meanwhile ``/departments/health`` (app/routers/
+--   departments.py) queries this view and returns 500 without it,
+--   bricking the /dashboard/departments page.
+--
+-- This migration restores the view independently of the trigger.
+-- Idempotent: CREATE OR REPLACE VIEW. Safe to re-run, and safe to
+-- coexist with a future re-application of the original 20260403400000
+-- migration (which uses the same CREATE OR REPLACE shape).
+
+CREATE OR REPLACE VIEW public.department_health_summary AS
+SELECT
+    d.id                AS department_id,
+    d.name              AS department_name,
+    d.type              AS department_type,
+    d.status            AS department_status,
+    COUNT(dt.id) FILTER (
+        WHERE dt.status IN ('pending', 'in_progress')
+    )                   AS active_tasks,
+    COUNT(dt.id) FILTER (
+        WHERE dt.status = 'completed'
+          AND dt.completed_at >= now() - INTERVAL '30 days'
+    )                   AS completed_30d,
+    COUNT(dt.id) FILTER (
+        WHERE dt.status IN ('pending', 'in_progress', 'completed')
+          AND dt.created_at >= now() - INTERVAL '30 days'
+    )                   AS total_30d,
+    CASE
+        WHEN COUNT(dt.id) FILTER (
+                 WHERE dt.created_at >= now() - INTERVAL '30 days'
+             ) = 0
+            THEN 'green'
+        WHEN (
+            COUNT(dt.id) FILTER (
+                WHERE dt.status = 'completed'
+                  AND dt.completed_at >= now() - INTERVAL '30 days'
+            )::FLOAT
+            / NULLIF(COUNT(dt.id) FILTER (
+                WHERE dt.status IN ('pending', 'in_progress', 'completed')
+                  AND dt.created_at >= now() - INTERVAL '30 days'
+            ), 0)
+        ) > 0.8
+            THEN 'green'
+        WHEN (
+            COUNT(dt.id) FILTER (
+                WHERE dt.status = 'completed'
+                  AND dt.completed_at >= now() - INTERVAL '30 days'
+            )::FLOAT
+            / NULLIF(COUNT(dt.id) FILTER (
+                WHERE dt.status IN ('pending', 'in_progress', 'completed')
+                  AND dt.created_at >= now() - INTERVAL '30 days'
+            ), 0)
+        ) > 0.5
+            THEN 'yellow'
+        ELSE 'red'
+    END                 AS health_status
+FROM public.departments d
+LEFT JOIN public.department_tasks dt ON dt.to_department_id = d.id
+GROUP BY d.id, d.name, d.type, d.status;


### PR DESCRIPTION
## Summary
- **Migration** `20260519160000_restore_department_health_summary_view.sql` — restores the `department_health_summary` view that `20260511120050_restore_department_tasks.sql` deferred. The view was missing from prod after the 2026-04-27 Cloud Run project move, causing `GET /departments/health` to return 500 and `/dashboard/departments` to render blank. Already applied to prod via the Supabase Management API (`CREATE OR REPLACE VIEW`); this commit lands the file in source control so future `supabase db push` runs stay in sync.
- **SSE auth fix** in `frontend/src/app/api/workspace/events/route.ts` — extracts the Supabase access_token from the auth cookie via the SSR client and injects it as `Authorization: Bearer <jwt>` to the FastAPI backend. Browser `EventSource` cannot send `Authorization` headers, so the prior cookie-only forwarding hit Bearer-only backend auth and returned 403, breaking `/dashboard/workspace` live updates. Mirrors the cookie → Bearer pattern in `sessions/list/route.ts`.

## Test plan
- [x] `npx vitest run src/app/api/workspace/events/route.test.ts` — 7/7 passing (5 original + 2 new cases for cookie-derived Bearer and explicit-header-wins).
- [x] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] Manual: `POST https://api.supabase.com/v1/projects/.../database/query` confirms view exists and returns 8 department rows.
- [x] Manual: `curl https://api.pikar-ai.com/departments/health` now returns 403 (auth-required) instead of 500 (server-error).
- [ ] After merge + Vercel deploy: reload `/dashboard/departments` while logged in — should render department cards instead of error state.
- [ ] After merge + Vercel deploy: reload `/dashboard/workspace` — `[useWorkspaceEvents] SSE error` should disappear from console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)